### PR TITLE
added Firestore service for grant-request collection

### DIFF
--- a/src/services/grantRequestService.ts
+++ b/src/services/grantRequestService.ts
@@ -1,0 +1,34 @@
+
+import { Entity, FirestoreService } from "@digitalaidseattle/firebase";
+
+
+export type GrantRequest = Entity & {
+  
+  title?: string;
+  description?: string;
+  requestedBy?: string;
+  createdAt: Date;
+  status?: "pending" | "approved" | "rejected";
+};
+
+class GrantRequestService extends FirestoreService<GrantRequest> {
+  constructor() {
+    //We have to create "grant-request" collection
+    super("grant-request");
+  }
+
+  empty(): GrantRequest {
+    return {
+      id: undefined,
+      title: "",
+      description: "",
+      requestedBy: "",
+      createdAt: new Date(),
+      status: "pending"
+    };
+  }
+
+
+}
+
+export const grantRequestService = new GrantRequestService();


### PR DESCRIPTION
- Define GrantRequest type extending Entity
- Add GrantRequestStatus union ("pending" | "approved" | "rejected") for type safety
- Implement GrantRequestService extending FirestoreService
- Provide empty() method with default status "pending"
- Export singleton grantRequestService for use in app
