### PR TITLE
Implement grant recipe detail page with output fields

### DIFF
--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -5,6 +5,14 @@ import { useNavigate } from "react-router-dom";
 import { grantRecipeService } from "../../services/grantRecipeService";
 import { GrantRecipe } from "../../types";
 import { grantProposalService } from "../../services/grantProposalService";
+import { 
+  FormControlLabel,
+  Stack, 
+  Switch,
+  TextField, 
+  Typography } from "@mui/material";
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import type { GrantOutput } from "../../types";
 
 const GrantRecipesDetailPage: React.FC = () => {
   const notifications = useNotifications();
@@ -44,8 +52,37 @@ const GrantRecipesDetailPage: React.FC = () => {
     }
   }
 
+  const [outputFields, setOutputFields] = useState<GrantOutput[]>([
+    { name: "description", maxWords: 500, unit: 'word' },
+    { name: "usage", maxWords: 500, unit: 'word' }
+  ]);
+
+  const handleOutputFieldChange = (index: number, field: 'name' | 'maxWords', value: string | number) => {
+    const newFields = [...outputFields];
+    newFields[index] = { ...newFields[index], [field]: value };
+    setOutputFields(newFields);
+  };
+
+  const handleOutputUnitToggle = (index: number) => {
+    const newFields = [...outputFields];
+    newFields[index] = {
+      ...newFields[index],
+      unit: newFields[index].unit === 'word' ? 'char' : 'word'
+    };
+    setOutputFields(newFields);
+  };
+
+  const handleAddOutputField = () => {
+    setOutputFields([...outputFields, { name: "", maxWords: 500, unit: 'word' }]);
+  };
+
+  const handleRemoveOutputField = (index: number) => {
+    setOutputFields(outputFields.filter((_, i) => i !== index));
+  };
   return (
-    <Card>
+    <div>
+      <Typography variant="h4">Grant Recipe Detail</Typography>
+      <Card>
       <CardHeader title="Grant Recipe Detail" />
       <CardContent>
         <Box>Description goes here</Box>
@@ -58,7 +95,56 @@ const GrantRecipesDetailPage: React.FC = () => {
         <Button variant="contained" disabled={loading} onClick={() => handleGenerate()}>Generate</Button>
       </CardActions>
     </Card>
+      <fieldset style={{ border: '1px solid #ccc', borderRadius: '4px', padding: '16px', marginTop: '16px' }}>
+        <legend style={{ padding: '0 8px' }}>Output Fields: (field / max word count)</legend>
+        <Stack spacing={2} sx={{ mt: 2 }}>
+          {outputFields.map((field, index) => (
+            <Stack direction="row" spacing={2} key={index} alignItems="center">
+              <TextField
+                label="Field"
+                value={field.name}
+                onChange={(e) => handleOutputFieldChange(index, 'name', e.target.value)}
+                sx={{ width: '200px' }}
+              />
+              <TextField
+                label={`Max ${field.unit === 'word' ? 'Words' : 'Characters'}`}
+                type="number"
+                value={field.maxWords}
+                onChange={(e) => handleOutputFieldChange(index, 'maxWords', parseInt(e.target.value) || 0)}
+                sx={{ width: '150px' }}
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={field.unit === 'char'}
+                    onChange={() => handleOutputUnitToggle(index)}
+                  />
+                }
+                label={field.unit === 'word' ? 'Words' : 'Chars'}
+              />
+              <Button
+                color="error"
+                onClick={() => handleRemoveOutputField(index)}
+                startIcon={<DeleteOutlined />}
+              >
+                Remove
+              </Button>
+            </Stack>
+          ))}
+          <Button
+            variant="outlined"
+            color="success"
+            onClick={handleAddOutputField}
+            startIcon={<PlusOutlined />}
+            sx={{ alignSelf: 'flex-start' }}
+          >
+            Add Output Field
+          </Button>
+        </Stack>
+      </fieldset>
+    </div>
   );
-};
+
+  }
 
 export default GrantRecipesDetailPage;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type GrantInput = {
 export type GrantOutput = {
     name: string;
     maxWords: number;
+    unit: 'word' | 'char';
 }
 
 export type GrantRecipe = Entity & {


### PR DESCRIPTION
## Description

#Wave 62

This PR implements the grant recipe detail page with output fields management functionality. The page allows users to define and manage output field specifications for grant recipes, including field names, maximum word/character limits, and the ability to toggle between word and character units.

**Key highlights for reviewers:**
- Each output field has a toggle to switch between word and character limits
- Add/remove functionality allows dynamic management of output fields
- Default fields are pre-populated with "description" and "usage" (500 words each)

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Changes Made

- ✅ Added output fields section with field name and max count inputs
- ✅ Implemented word/character toggle for each output field limit
- ✅ Added add/remove functionality for dynamic output fields management
- ✅ Updated GrantOutput type to support unit (word/char) and maxWords
- ✅ Pre-populated default fields: "description" and "usage" (500 words each)

## Files Modified

- `src/pages/grants/GrantRecipesDetailPage.tsx` - Complete implementation of detail page with output fields
- `src/types.ts` - Updated GrantOutput type to support unit (word/char)

##Screenshot

<img width="760" height="422" alt="image" src="https://github.com/user-attachments/assets/2f8b5d54-af36-4155-aaf0-d70186944e95" />

