### PR TITLE
Feature/add proposal validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@ant-design/colors": "^7.0.2",
         "@ant-design/icons": "^5.3.0",
-        "@digitalaidseattle/core": "^1.0.8",
-        "@digitalaidseattle/firebase": "^1.0.4",
-        "@digitalaidseattle/mui": "^1.0.16",
+        "@digitalaidseattle/core": "^1.0.13",
+        "@digitalaidseattle/firebase": "^1.0.7",
+        "@digitalaidseattle/mui": "^1.0.28",
         "@mui/material": "^5.15.9",
         "react": "^18.2.0",
         "react-apexcharts": "^1.4.1",
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@digitalaidseattle/core": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@digitalaidseattle/core/-/core-1.0.11.tgz",
-      "integrity": "sha512-0dNgvjtagGEredcSoVmTvL5jWWutTVI9y3l0Y+r3yeJFttlczOaHviPEqKrzKc0stSmR1rlXXpWs1alxT9MuOQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@digitalaidseattle/core/-/core-1.0.13.tgz",
+      "integrity": "sha512-YSwxWTmsNtLb7VCwHOYy/4hZdyL0FDu9WRnhmmMGD9UuyxHmoRDpTkmDXFzZVOU505mqrBCG5488yL6SUigSyQ==",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "react": "^18.3.1",
@@ -390,27 +390,21 @@
       }
     },
     "node_modules/@digitalaidseattle/firebase": {
-<<<<<<< HEAD
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@digitalaidseattle/firebase/-/firebase-1.0.4.tgz",
-      "integrity": "sha512-eM9KRhSwSY5ZSQp0AqjuyI44IerREiFiuPX1r3B7WuQ4GWbiLQvi4EeLjilVZqch/TsVV9N2Y6dnQMQ4X+jYSw==",
-=======
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@digitalaidseattle/firebase/-/firebase-1.0.6.tgz",
-      "integrity": "sha512-+dM+kki7fwcJTfZUvNbHHfZBE7U0xmLfQH6mDR7d9DX9bYBSX3HOm1yISo8mOnRRDUqzgsPD01wDdem8TM6GMA==",
->>>>>>> dev
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@digitalaidseattle/firebase/-/firebase-1.0.7.tgz",
+      "integrity": "sha512-+1lzEpYbc/u76QLT0NkeDltPybZEqsSBQPN7PI1vRtGlhj4L/rrO5EG2XFrKKVSnJhEX3Usv85vOYsXjeHqwOw==",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
-        "@digitalaidseattle/core": "1.0.10",
+        "@digitalaidseattle/core": "1.0.12",
         "firebase": "^11.2.0",
         "react": "^18.3.1",
         "uuid": "^11.0.5"
       }
     },
     "node_modules/@digitalaidseattle/firebase/node_modules/@digitalaidseattle/core": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@digitalaidseattle/core/-/core-1.0.10.tgz",
-      "integrity": "sha512-0Z4qN1FBTbB3GNDS3j7YgvSjT81lAfW12kml4tFMkx13oyNbtqa3dHxAXA/BlrSOBtJSucqic/1QlVZb+2/5pg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@digitalaidseattle/core/-/core-1.0.12.tgz",
+      "integrity": "sha512-+wolQk6Qlu9jihT+j+iH/bXZKz4gD0U8vnqrXgqizBwj7zCW4heG5HMTEvys1XdTNWkWf2Vx13yWiC1QdTR30w==",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "react": "^18.3.1",
@@ -419,14 +413,14 @@
       }
     },
     "node_modules/@digitalaidseattle/mui": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@digitalaidseattle/mui/-/mui-1.0.26.tgz",
-      "integrity": "sha512-PF4QVc9tz0P8RtP80v/vJo3GIHZFv7gyp46LRPIsjP7pYhOGJOFbSD0kaK2Uh6+/oVpjNkYpdwiZY+j7scqDgw==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@digitalaidseattle/mui/-/mui-1.0.28.tgz",
+      "integrity": "sha512-hGTCaU9HCTadbuwbESFEY9IsY7DmMICX0CkYaqtE0gAUkWWKziZevCZwzQHDWHbknvViYgSlruSUPsfb+2v/MA==",
       "dependencies": {
         "@ant-design/colors": "^7.0.2",
         "@ant-design/icons": "^5.3.0",
         "@babel/runtime": "^7.25.0",
-        "@digitalaidseattle/core": "1.0.11",
+        "@digitalaidseattle/core": "1.0.13",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^7.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,15 @@
         "@ant-design/colors": "^7.0.2",
         "@ant-design/icons": "^5.3.0",
         "@digitalaidseattle/core": "^1.0.8",
-        "@digitalaidseattle/firebase": "^1.0.3",
+        "@digitalaidseattle/firebase": "^1.0.4",
         "@digitalaidseattle/mui": "^1.0.16",
         "@mui/material": "^5.15.9",
         "react": "^18.2.0",
         "react-apexcharts": "^1.4.1",
         "react-dom": "^18.2.0",
         "react-router": "^6.22.0",
-        "react-router-dom": "^6.22.0"
+        "react-router-dom": "^6.22.0",
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "@testing-library/react": "^14.2.1",
@@ -389,9 +390,9 @@
       }
     },
     "node_modules/@digitalaidseattle/firebase": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@digitalaidseattle/firebase/-/firebase-1.0.3.tgz",
-      "integrity": "sha512-71hSHn/68b4c48R7IOBP0xem6VPC8RN29xTw/vEbcjIpXOa5MBD0okPRL8pCt2n9hE4KSJycPyTcC3gqif9SaQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@digitalaidseattle/firebase/-/firebase-1.0.4.tgz",
+      "integrity": "sha512-eM9KRhSwSY5ZSQp0AqjuyI44IerREiFiuPX1r3B7WuQ4GWbiLQvi4EeLjilVZqch/TsVV9N2Y6dnQMQ4X+jYSw==",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@digitalaidseattle/core": "1.0.8",
@@ -9220,6 +9221,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "@ant-design/colors": "^7.0.2",
     "@ant-design/icons": "^5.3.0",
     "@digitalaidseattle/core": "^1.0.8",
-    "@digitalaidseattle/mui": "^1.0.16",
     "@digitalaidseattle/firebase": "^1.0.4",
+    "@digitalaidseattle/mui": "^1.0.16",
     "@mui/material": "^5.15.9",
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.1",
     "react-dom": "^18.2.0",
     "react-router": "^6.22.0",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^6.22.0",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "@ant-design/colors": "^7.0.2",
     "@ant-design/icons": "^5.3.0",
-    "@digitalaidseattle/core": "^1.0.8",
-    "@digitalaidseattle/firebase": "^1.0.4",
-    "@digitalaidseattle/mui": "^1.0.16",
+    "@digitalaidseattle/core": "^1.0.13",
+    "@digitalaidseattle/firebase": "^1.0.7",
+    "@digitalaidseattle/mui": "^1.0.28",
     "@mui/material": "^5.15.9",
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.1",

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,13 @@
+  // Basic validation rules stored in one place
+export const VALIDATION = {
+    MIN_LEN: 1,
+    RATING_MIN: 0,
+    RATING_MAX: 5,
+  } as const;
+  
+  // Reusable error messages for form fields
+  export const MSG = {
+    required: (label: string) => `${label} is required`,
+    ratingRange: (min: number, max: number) => `Rating must be between ${min} and ${max}`,
+  };
+  

--- a/src/services/validation/ValidationService.test.ts
+++ b/src/services/validation/ValidationService.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { ValidationService } from "./ValidationService";
+
+describe("ValidationService", () => {
+  const svc = new ValidationService();
+
+  // --- Proposals ---
+
+  it("rejects invalid proposal (missing grantRecipeId)", () => {
+    const r = svc.validateGrantProposal({} as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.grantRecipeId).toBeTruthy();
+  });
+
+  it("accepts minimal valid proposal", () => {
+    const r = svc.validateGrantProposal({
+      grantRecipeId: "abc123",
+      rating: null,
+    } as any);
+    expect(r.valid).toBe(true);
+  });
+
+  it("rejects rating out of range", () => {
+    const r = svc.validateGrantProposal({
+      grantRecipeId: "abc123",
+      rating: 6,
+    } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.rating).toBeTruthy();
+  });
+
+  it("trims strings for required fields", () => {
+    const r = svc.validateGrantProposal({
+      grantRecipeId: "  abc123  ",
+      rating: null,
+    } as any);
+    expect(r.valid).toBe(true);
+  });
+
+  it("accepts rating at boundaries", () => {
+    expect(svc.validateGrantProposal({ grantRecipeId: "id", rating: 0 } as any).valid).toBe(true);
+    expect(svc.validateGrantProposal({ grantRecipeId: "id", rating: 5 } as any).valid).toBe(true);
+  });
+
+  it("rejects non-number rating", () => {
+    const r = svc.validateGrantProposal({ grantRecipeId: "id", rating: "5" as any } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.rating).toBeTruthy();
+  });
+
+  it("requires structuredResponse values to be strings", () => {
+    const ok = svc.validateGrantProposal({
+      grantRecipeId: "id",
+      structuredResponse: { a: "b" },
+    } as any);
+    const bad = svc.validateGrantProposal({
+      grantRecipeId: "id",
+      structuredResponse: { a: 1 as any },
+    } as any);
+
+    expect(ok.valid).toBe(true);
+    expect(bad.valid).toBe(false);
+    expect(bad.errors["structuredResponse.a"]).toBeTruthy();
+  });
+
+  // --- Recipes ---
+
+  it("rejects invalid recipe (missing required fields)", () => {
+    const r = svc.validateGrantRecipe({} as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.description).toBeTruthy();
+    expect(r.errors.prompt).toBeTruthy();
+    expect(r.errors.modelType).toBeTruthy();
+  });
+
+  it("accepts minimal valid recipe", () => {
+    const r = svc.validateGrantRecipe({
+      description: "x",
+      prompt: "y",
+      modelType: "gemini-2.5-flash",
+    } as any);
+    expect(r.valid).toBe(true);
+  });
+
+  it("validates inputParameters items and exposes index path", () => {
+    const r = svc.validateGrantRecipe({
+      description: "d",
+      prompt: "p",
+      modelType: "m",
+      inputParameters: [{ key: "", value: "x" }],
+    } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors["inputParameters.0.key"]).toBeTruthy();
+  });
+
+  it("maxWords must be ≥ 0 in outputsWithWordCount", () => {
+    const r = svc.validateGrantRecipe({
+      description: "d",
+      prompt: "p",
+      modelType: "m",
+      outputsWithWordCount: [{ name: "Summary", maxWords: -1 }],
+    } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors["outputsWithWordCount.0.maxWords"]).toBeTruthy();
+  });
+
+  it("allows optional fields to be omitted", () => {
+    const r1 = svc.validateGrantRecipe({
+      description: "d",
+      prompt: "p",
+      modelType: "m",
+    } as any);
+    expect(r1.valid).toBe(true);
+
+    const r2 = svc.validateGrantProposal({
+      grantRecipeId: "id",
+    } as any);
+    expect(r2.valid).toBe(true);
+  });
+});

--- a/src/services/validation/ValidationService.ts
+++ b/src/services/validation/ValidationService.ts
@@ -1,4 +1,3 @@
-// runs schema checks and returns { valid, errors }
 import { z } from "zod";
 import {
   grantProposalSchema,
@@ -9,24 +8,38 @@ import {
 
 export type ValidationResult = { valid: boolean; errors: Record<string, string> };
 
-// turn Zod issues into { field: message }
+// zod issues -> { field: message }
 const mapIssues = (issues: z.ZodError["issues"]): Record<string, string> => {
   const out: Record<string, string> = {};
   for (const issue of issues) {
-    const key = issue.path.join("."); // "description" or "inputParameters.0.key"
+    const key = issue.path.join(".");
     if (!out[key]) out[key] = issue.message;
   }
   return out;
 };
 
-export class ValidationService {
-  static validateGrantRecipe(data: GrantRecipeInput): ValidationResult {
-    const r = grantRecipeSchema.safeParse(data);
+// Small interface so tests can mock/replace this easily
+export interface IValidationService {
+  validateGrantRecipe(data: GrantRecipeInput): ValidationResult;
+  validateGrantProposal(data: GrantProposalInput): ValidationResult;
+}
+
+// Instance based; schemas are injectable for tests
+export class ValidationService implements IValidationService {
+  constructor(
+    private readonly recipeSchema = grantRecipeSchema,
+    private readonly proposalSchema = grantProposalSchema
+  ) {}
+
+  validateGrantRecipe(data: GrantRecipeInput): ValidationResult {
+    const r = this.recipeSchema.safeParse(data);
     return r.success ? { valid: true, errors: {} } : { valid: false, errors: mapIssues(r.error.issues) };
   }
 
-  static validateGrantProposal(data: GrantProposalInput): ValidationResult {
-    const r = grantProposalSchema.safeParse(data);
+  validateGrantProposal(data: GrantProposalInput): ValidationResult {
+    const r = this.proposalSchema.safeParse(data);
     return r.success ? { valid: true, errors: {} } : { valid: false, errors: mapIssues(r.error.issues) };
   }
 }
+
+export const validationService = new ValidationService();

--- a/src/services/validation/ValidationService.ts
+++ b/src/services/validation/ValidationService.ts
@@ -13,7 +13,7 @@ export type ValidationResult = { valid: boolean; errors: Record<string, string> 
 const mapIssues = (issues: z.ZodError["issues"]): Record<string, string> => {
   const out: Record<string, string> = {};
   for (const issue of issues) {
-    const key = issue.path.join("."); // e.g., "description" or "inputParameters.0.key"
+    const key = issue.path.join("."); // "description" or "inputParameters.0.key"
     if (!out[key]) out[key] = issue.message;
   }
   return out;

--- a/src/services/validation/ValidationService.ts
+++ b/src/services/validation/ValidationService.ts
@@ -1,0 +1,32 @@
+// runs schema checks and returns { valid, errors }
+import { z } from "zod";
+import {
+  grantProposalSchema,
+  grantRecipeSchema,
+  type GrantProposalInput,
+  type GrantRecipeInput,
+} from "./schemas";
+
+export type ValidationResult = { valid: boolean; errors: Record<string, string> };
+
+// turn Zod issues into { field: message }
+const mapIssues = (issues: z.ZodError["issues"]): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const issue of issues) {
+    const key = issue.path.join("."); // e.g., "description" or "inputParameters.0.key"
+    if (!out[key]) out[key] = issue.message;
+  }
+  return out;
+};
+
+export class ValidationService {
+  static validateGrantRecipe(data: GrantRecipeInput): ValidationResult {
+    const r = grantRecipeSchema.safeParse(data);
+    return r.success ? { valid: true, errors: {} } : { valid: false, errors: mapIssues(r.error.issues) };
+  }
+
+  static validateGrantProposal(data: GrantProposalInput): ValidationResult {
+    const r = grantProposalSchema.safeParse(data);
+    return r.success ? { valid: true, errors: {} } : { valid: false, errors: mapIssues(r.error.issues) };
+  }
+}

--- a/src/services/validation/schemas.ts
+++ b/src/services/validation/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { MSG, VALIDATION } from "../../constants/validation";
 
-// required trimmed text (e.g., "Title is required")
+// required trimmed text ("Title is required", etc)
 const req = (label: string) =>
   z.string().trim().min(VALIDATION.MIN_LEN, { message: MSG.required(label) });
 

--- a/src/services/validation/schemas.ts
+++ b/src/services/validation/schemas.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { MSG, VALIDATION } from "../../constants/validation";
+
+// required trimmed text (e.g., "Title is required")
+const req = (label: string) =>
+  z.string().trim().min(VALIDATION.MIN_LEN, { message: MSG.required(label) });
+
+// GrantInput { key, value }
+const grantInput = z.object({
+  key: req("Key"),
+  value: req("Value"),
+});
+
+// GrantOutput { name, maxWords }
+const grantOutput = z.object({
+  name: req("Name"),
+  maxWords: z.number().int().gte(0),
+});
+
+// Recipe rules (only the fields that matter today)
+export const grantRecipeSchema = z.object({
+  description: req("Description"),
+  prompt: req("Prompt"),
+  modelType: req("Model type"),
+
+  tokenString: z.string().trim().optional(),
+  tokenCount: z.number().int().nonnegative().optional(),
+
+  inputParameters: z.array(grantInput).optional(),
+  outputsWithWordCount: z.array(grantOutput).optional(),
+  proposalIds: z.array(z.string().trim()).optional(),
+});
+
+// Proposal rules
+export const grantProposalSchema = z.object({
+  grantRecipeId: req("Grant recipe"),
+  rating: z.number().min(VALIDATION.RATING_MIN).max(VALIDATION.RATING_MAX).nullable().optional(),
+  textResponse: z.string().trim().optional(),
+  structuredResponse: z.record(z.string(), z.string()).optional(), // { [key: string]: string }
+});
+
+// exported input types for callers
+export type GrantRecipeInput = z.input<typeof grantRecipeSchema>;
+export type GrantProposalInput = z.input<typeof grantProposalSchema>;


### PR DESCRIPTION
## Description

- Implemented client-side validation for GrantRecipe and GrantProposal forms.  
- Added `ValidationService` (now instance-based) and Zod-based schemas to define required fields and rules.  
- Centralized constants and messages in `validation.ts` for easier updates.  
- Validation runs entirely on the client, blocking invalid submissions and allowing drafts to save.  
- Added comprehensive test coverage for both GrantRecipe and GrantProposal validation, including edge cases (trimming, rating boundaries, nested array paths, etc.).  
- Updated documentation to reflect instance-based usage (`validationService` instead of `ValidationService`) and to show import examples.  
-  **Documentation:** [Validation Guide](https://docs.google.com/document/d/1iuBbhaIoKDiprkNxfsrAUhEiJlJ9Dz9yfnCePV5KyXw/edit?usp=sharing)

## What type of PR is this? (check all applicable)

- [ ] Refactor  
- [x] Feature  
- [ ] Bug Fix  
- [ ] Optimization  


## Related Tickets & Documents
- Jira Story: [WAVE-42](https://digital-aid-seattle.atlassian.net/browse/WAVE-42)

