### PR TITLE
proposal validation UPDATED

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-apexcharts": "^1.4.1",
         "react-dom": "^18.2.0",
         "react-router": "^6.22.0",
-        "react-router-dom": "^6.22.0"
+        "react-router-dom": "^6.22.0",
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "@testing-library/react": "^14.2.1",
@@ -9441,6 +9442,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "@ant-design/colors": "^7.0.2",
     "@ant-design/icons": "^5.3.0",
     "@digitalaidseattle/core": "^1.0.8",
-    "@digitalaidseattle/mui": "^1.0.16",
     "@digitalaidseattle/firebase": "^1.0.4",
+    "@digitalaidseattle/mui": "^1.0.16",
     "@mui/material": "^5.15.9",
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.1",
     "react-dom": "^18.2.0",
     "react-router": "^6.22.0",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^6.22.0",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.1",

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,12 @@
+// Basic validation rules stored in one place
+export const VALIDATION = {
+    MIN_LEN: 1,
+    RATING_MIN: 0,
+    RATING_MAX: 5,
+  } as const;
+
+  // Reusable error messages for form fields
+  export const MSG = {
+    required: (label: string) => `${label} is required`,
+    ratingRange: (min: number, max: number) => `Rating must be between ${min} and ${max}`,
+  };

--- a/src/services/validation/ValidationService.test.ts
+++ b/src/services/validation/ValidationService.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { ValidationService } from "./ValidationService";
+
+describe("ValidationService", () => {
+  const svc = new ValidationService();
+
+  // --- Proposals ---
+
+  it("rejects invalid proposal (missing grantRecipeId)", () => {
+    const r = svc.validateGrantProposal({} as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.grantRecipeId).toBeTruthy();
+  });
+
+  it("accepts minimal valid proposal", () => {
+    const r = svc.validateGrantProposal({
+      grantRecipeId: "abc123",
+      rating: null,
+    } as any);
+    expect(r.valid).toBe(true);
+  });
+
+  it("rejects rating out of range", () => {
+    const r = svc.validateGrantProposal({
+      grantRecipeId: "abc123",
+      rating: 6,
+    } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.rating).toBeTruthy();
+  });
+
+  it("trims strings for required fields", () => {
+    const r = svc.validateGrantProposal({
+      grantRecipeId: "  abc123  ",
+      rating: null,
+    } as any);
+    expect(r.valid).toBe(true);
+  });
+
+  it("accepts rating at boundaries", () => {
+    expect(svc.validateGrantProposal({ grantRecipeId: "id", rating: 0 } as any).valid).toBe(true);
+    expect(svc.validateGrantProposal({ grantRecipeId: "id", rating: 5 } as any).valid).toBe(true);
+  });
+
+  it("rejects non-number rating", () => {
+    const r = svc.validateGrantProposal({ grantRecipeId: "id", rating: "5" as any } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.rating).toBeTruthy();
+  });
+
+  it("requires structuredResponse values to be strings", () => {
+    const ok = svc.validateGrantProposal({
+      grantRecipeId: "id",
+      structuredResponse: { a: "b" },
+    } as any);
+    const bad = svc.validateGrantProposal({
+      grantRecipeId: "id",
+      structuredResponse: { a: 1 as any },
+    } as any);
+
+    expect(ok.valid).toBe(true);
+    expect(bad.valid).toBe(false);
+    expect(bad.errors["structuredResponse.a"]).toBeTruthy();
+  });
+
+  // --- Recipes ---
+
+  it("rejects invalid recipe (missing required fields)", () => {
+    const r = svc.validateGrantRecipe({} as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors.description).toBeTruthy();
+    expect(r.errors.prompt).toBeTruthy();
+    expect(r.errors.modelType).toBeTruthy();
+  });
+
+  it("accepts minimal valid recipe", () => {
+    const r = svc.validateGrantRecipe({
+      description: "x",
+      prompt: "y",
+      modelType: "gemini-2.5-flash",
+    } as any);
+    expect(r.valid).toBe(true);
+  });
+
+  it("validates inputParameters items and exposes index path", () => {
+    const r = svc.validateGrantRecipe({
+      description: "d",
+      prompt: "p",
+      modelType: "m",
+      inputParameters: [{ key: "", value: "x" }],
+    } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors["inputParameters.0.key"]).toBeTruthy();
+  });
+
+  it("maxWords must be ≥ 0 in outputsWithWordCount", () => {
+    const r = svc.validateGrantRecipe({
+      description: "d",
+      prompt: "p",
+      modelType: "m",
+      outputsWithWordCount: [{ name: "Summary", maxWords: -1 }],
+    } as any);
+    expect(r.valid).toBe(false);
+    expect(r.errors["outputsWithWordCount.0.maxWords"]).toBeTruthy();
+  });
+
+  it("allows optional fields to be omitted", () => {
+    const r1 = svc.validateGrantRecipe({
+      description: "d",
+      prompt: "p",
+      modelType: "m",
+    } as any);
+    expect(r1.valid).toBe(true);
+
+    const r2 = svc.validateGrantProposal({
+      grantRecipeId: "id",
+    } as any);
+    expect(r2.valid).toBe(true);
+  });
+});

--- a/src/services/validation/ValidationService.ts
+++ b/src/services/validation/ValidationService.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import {
+  grantProposalSchema,
+  grantRecipeSchema,
+  type GrantProposalInput,
+  type GrantRecipeInput,
+} from "./schemas";
+
+export type ValidationResult = { valid: boolean; errors: Record<string, string> };
+
+// zod issues -> { field: message }
+const mapIssues = (issues: z.ZodError["issues"]): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const issue of issues) {
+    const key = issue.path.join(".");
+    if (!out[key]) out[key] = issue.message;
+  }
+  return out;
+};
+
+// Small interface so tests can mock/replace this easily
+export interface IValidationService {
+  validateGrantRecipe(data: GrantRecipeInput): ValidationResult;
+  validateGrantProposal(data: GrantProposalInput): ValidationResult;
+}
+
+// Instance based; schemas are injectable for tests
+export class ValidationService implements IValidationService {
+  constructor(
+    private readonly recipeSchema = grantRecipeSchema,
+    private readonly proposalSchema = grantProposalSchema
+  ) {}
+
+  validateGrantRecipe(data: GrantRecipeInput): ValidationResult {
+    const r = this.recipeSchema.safeParse(data);
+    return r.success ? { valid: true, errors: {} } : { valid: false, errors: mapIssues(r.error.issues) };
+  }
+
+  validateGrantProposal(data: GrantProposalInput): ValidationResult {
+    const r = this.proposalSchema.safeParse(data);
+    return r.success ? { valid: true, errors: {} } : { valid: false, errors: mapIssues(r.error.issues) };
+  }
+}
+
+export const validationService = new ValidationService();

--- a/src/services/validation/schemas.ts
+++ b/src/services/validation/schemas.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { MSG, VALIDATION } from "../../constants/validation";
+
+// required trimmed text ("Title is required", etc)
+const req = (label: string) =>
+  z.string().trim().min(VALIDATION.MIN_LEN, { message: MSG.required(label) });
+
+// GrantInput { key, value }
+const grantInput = z.object({
+  key: req("Key"),
+  value: req("Value"),
+});
+
+// GrantOutput { name, maxWords }
+const grantOutput = z.object({
+  name: req("Name"),
+  maxWords: z.number().int().gte(0),
+});
+
+// Recipe rules (only the fields that matter today)
+export const grantRecipeSchema = z.object({
+  description: req("Description"),
+  prompt: req("Prompt"),
+  modelType: req("Model type"),
+
+  tokenString: z.string().trim().optional(),
+  tokenCount: z.number().int().nonnegative().optional(),
+
+  inputParameters: z.array(grantInput).optional(),
+  outputsWithWordCount: z.array(grantOutput).optional(),
+  proposalIds: z.array(z.string().trim()).optional(),
+});
+
+// Proposal rules
+export const grantProposalSchema = z.object({
+  grantRecipeId: req("Grant recipe"),
+  rating: z.number().min(VALIDATION.RATING_MIN).max(VALIDATION.RATING_MAX).nullable().optional(),
+  textResponse: z.string().trim().optional(),
+  structuredResponse: z.record(z.string(), z.string()).optional(), // { [key: string]: string }
+});
+
+// exported input types for callers
+export type GrantRecipeInput = z.input<typeof grantRecipeSchema>;
+export type GrantProposalInput = z.input<typeof grantProposalSchema>;


### PR DESCRIPTION
## Description

- Implemented client-side validation for GrantRecipe and GrantProposal forms.  
- Added `ValidationService` (now instance-based) and Zod-based schemas to define required fields and rules.  
- Centralized constants and messages in `validation.ts` for easier updates.  
- Validation runs entirely on the client, blocking invalid submissions and allowing drafts to save.  
- Added comprehensive test coverage for both GrantRecipe and GrantProposal validation, including edge cases (trimming, rating boundaries, nested array paths, etc.).  
- Updated documentation to reflect instance-based usage (`validationService` instead of `ValidationService`) and to show import examples.  
-  **Documentation:** [Validation Guide](https://docs.google.com/document/d/1iuBbhaIoKDiprkNxfsrAUhEiJlJ9Dz9yfnCePV5KyXw/edit?usp=sharing)

## What type of PR is this? (check all applicable)

- [ ] Refactor  
- [x] Feature  
- [ ] Bug Fix  
- [ ] Optimization  


## Related Tickets & Documents
- Jira Story: [WAVE-42](https://digital-aid-seattle.atlassian.net/browse/WAVE-42)

