### PR TITLE
Feature/wire generate button

### DIFF
--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -124,10 +124,10 @@ const GrantRecipesDetailPage: React.FC = () => {
       try {
         setLoading(true);
     
-        // 1) AI -> returns a draft proposal object (not saved)
+        //AI -> returns a draft proposal object (not saved)
         const draft = await grantProposalService.generate(recipe);
     
-        // 2) Persist proposal
+        // Persist proposal
         const saved = await grantProposalService.insert(
           {
             ...draft,
@@ -141,7 +141,7 @@ const GrantRecipesDetailPage: React.FC = () => {
     
         notifications.success(`Proposal generated for ${recipe.description}.`);
     
-        // 3) Navigate to proposal detail
+        //Navigate to proposal detail
         navigate(`/grant-proposals/${saved.id}`);
       } catch (err: any) {
         console.error(err);

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -118,21 +118,42 @@ const GrantRecipesDetailPage: React.FC = () => {
     }
   }
 
-  function handleGenerate() {
-    if (recipe) {
-      setLoading(true);
-      grantProposalService.generate(recipe)
-        .then(_generated => {
-          // Add generated to list of proposals?
-          notifications.success(`A proposal for ${recipe.description} has been successfully generated.`)
-        })
-        .catch(err => {
-          console.error(err)
-          notifications.error(`Could not generate a proposal for his recipe. ${err.message}`)
-        })
-        .finally(() => setLoading(false))
+  async function handleGenerate() {
+      if (!recipe || !user) return;
+    
+      try {
+        setLoading(true);
+    
+        // 1) AI -> returns a draft proposal object (not saved)
+        const draft = await grantProposalService.generate(recipe);
+    
+        // 2) Persist proposal
+        const saved = await grantProposalService.insert(
+          {
+            ...draft,
+            // make sure the proposal points back to this recipe
+            grantRecipeId: String(recipe.id),
+          },
+          undefined,
+          undefined,
+          user
+        );
+    
+        notifications.success(`Proposal generated for ${recipe.description}.`);
+    
+        // 3) Navigate to proposal detail
+        navigate(`/grant-proposals/${saved.id}`);
+      } catch (err: any) {
+        console.error(err);
+        notifications.error(
+          `Could not generate a proposal for this recipe. ${
+            err?.message ?? "Unknown error"
+          }`
+        );
+      } finally {
+        setLoading(false);
+      }
     }
-  }
 
   function updatePrompt(changed: GrantRecipe): Promise<GrantRecipe> {
     return grantRecipeService.updatePrompt(changed);

--- a/src/services/grantProposalService.ts
+++ b/src/services/grantProposalService.ts
@@ -22,25 +22,31 @@ class GrantProposalService extends FirestoreService<GrantProposal> {
   }
 
   // Insert a new proposal with metadata added
-  async insert(
-    entity: GrantProposal,
-    select?: string,
-    mapper?: (json: any) => GrantProposal,
-    user?: User
-  ): Promise<GrantProposal> {
-    if (!user?.email) throw new Error("User email is required");
+// Insert a new proposal with metadata added
+async insert(
+  entity: GrantProposal,
+  select?: string,
+  mapper?: (json: any) => GrantProposal,
+  user?: User
+): Promise<GrantProposal> {
+  if (!user?.email) throw new Error("User email is required");
 
-    return super.insert(
-      {
-        ...entity,
-        createdAt: new Date(),
-        createdBy: user.email,
-      },
-      select,
-      mapper,
-      user
-    );
-  }
+  // Firestore can't store `undefined` (and we don't want to persist id anyway)
+  // so remove it before insert.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, ...entityWithoutId } = entity;
+
+  return super.insert(
+    {
+      ...entityWithoutId,
+      createdAt: new Date(),
+      createdBy: user.email,
+    } as GrantProposal,
+    select,
+    mapper,
+    user
+  );
+}
 
   // Update a proposal
   async update(
@@ -104,16 +110,31 @@ class GrantProposalService extends FirestoreService<GrantProposal> {
     select?: string,
     mapper?: (json: any) => GrantProposal
   ): Promise<GrantProposal[]> {
-    if (import.meta.env.DEV) return this.mockAll();
+    if (import.meta.env.DEV) {
+      // show mocks + whatever is actually in Firestore
+      try {
+        const real = await super.getAll(count, select, mapper);
+        return [...this.mockAll(), ...(real ?? [])];
+      } catch {
+        return this.mockAll();
+      }
+    }
+  
     return super.getAll(count, select, mapper);
   }
-
+  
   async getById(
     entityId: string,
     select?: string,
     mapper?: (json: any) => GrantProposal
   ): Promise<GrantProposal> {
-    if (import.meta.env.DEV) return this.mockProposal(entityId);
+    if (import.meta.env.DEV) {
+      // only intercept the known mock ids
+      if (String(entityId).startsWith("test-")) {
+        return this.mockProposal(entityId);
+      }
+    }
+  
     return super.getById(entityId, select, mapper);
   }
 

--- a/src/services/grantProposalService.ts
+++ b/src/services/grantProposalService.ts
@@ -22,7 +22,6 @@ class GrantProposalService extends FirestoreService<GrantProposal> {
   }
 
   // Insert a new proposal with metadata added
-// Insert a new proposal with metadata added
 async insert(
   entity: GrantProposal,
   select?: string,


### PR DESCRIPTION
## Description

- Wired up the **Generate** button end-to-end so a Grant Proposal can now be generated from an existing Grant Recipe, persisted, and navigated to the proposal detail page.
- Verified that AI generation works and that structured output is saved and rendered correctly in the proposal detail view.
- Noted some **current limitations with the Grant Recipe editor**:
  - Input Parameters, Output Fields, Description, and Prompt appear to auto-regenerate or reset while editing, which made it difficult to freely enter custom values for testing.
  - As a result, testing was done using only the values the UI allowed to persist at the time.
- Despite the above, the **core generation flow is working** (Generate → AI → save proposal → view proposal).
- Flagging the editor behavior as a follow-up item to confirm whether this is expected auto-save / prompt-regeneration behavior or something that needs adjustment.

This PR focuses on validating and wiring the generation flow; editor UX issues can be addressed separately if needed.

## What type of PR is this? (check all applicable)

- [ ] Refactor  
- [x] Feature  
- [ ] Bug Fix  
- [ ] Optimization  
- [ ] Documentation Update  

## Related Tickets & Documents

https://digital-aid-seattle.atlassian.net/browse/WAVE-103

