### PR TITLE
WAVE 136 - add delete button to grant recipe detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Nonprofit staff spend hours repeating core narratives and trimming sections to f
    * `VITE_FIREBASE_MESSAGING_SENDER_ID`
    * `VITE_FIREBASE_APP_ID`
    * `VITE_FIREBASE_MEASUREMENT_ID`
-   * `VITE_AUTH_DOMAIN` for auth callbacks when required  
+   * `VITE_AUTH_DOMAIN` for auth callbacks when required
+   * `VITE_GEMINI_API_KEY` for Google Gemini AI (get from [Google Cloud Console](https://console.cloud.google.com/apis/credentials))
+   * `VITE_FIREBASE_STORAGE_FOLDER` for Firebase storage bucket folder
+   
    Ensure the Firebase project has Generative Language API and Firebase AI enabled.
 4. Start the dev server: `npm run dev`.
 5. Open `http://localhost:3000` and sign in with the configured provider to load grant recipes and drafts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "handlebars": "^4.7.8",
         "mammoth": "^1.11.0",
         "react-apexcharts": "^1.4.1",
-        "react-dropzone": "^14.4.0",
+        "react-dropzone": "^14.4.1",
         "zod": "^4.1.12"
       },
       "devDependencies": {
@@ -8266,9 +8266,9 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.4.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.0.tgz",
-      "integrity": "sha512-8VvsHqg9WGAr+wAnP0oVErK5HOwAoTOzRsxLPzbBXrtXtFfukkxMyuvdI/lJ+5OxtsrzmvWE5Eoo3Y4hMsaxpA==",
+      "version": "14.4.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
+      "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
       "license": "MIT",
       "dependencies": {
         "attr-accept": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "handlebars": "^4.7.8",
     "mammoth": "^1.11.0",
     "react-apexcharts": "^1.4.1",
-    "react-dropzone": "^14.4.0",
+    "react-dropzone": "^14.4.1",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -292,7 +292,7 @@ const GrantRecipesDetailPage: React.FC = () => {
                   {/* Delete Confirmation Dialog */}
                   <Dialog
                     open={openDeleteDialog}
-                    onClose={(event, reason) => {
+                    onClose={(_event, reason) => {
                       if (reason === 'backdropClick' && isDeleting) return;
                       handleDeleteCancel();
                     }}

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -5,7 +5,8 @@
 */
 import { HomeOutlined, InfoCircleOutlined } from "@ant-design/icons";
 import { LoadingContext, useHelp, useNotifications } from "@digitalaidseattle/core";
-import { Box, Breadcrumbs, Button, Card, CardActions, CardContent, CardHeader, Divider, IconButton, Stack, TextField, Tooltip, Typography } from "@mui/material";
+import { Box, Breadcrumbs, Button, Card, CardActions, CardContent, CardHeader, Divider, IconButton, Stack, TextField, Tooltip, Typography, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from "@mui/material";
+import DeleteIcon from '@mui/icons-material/Delete';
 import { useContext, useEffect, useState } from "react";
 import { NavLink, useNavigate, useParams } from "react-router-dom";
 import { HelpDrawer } from "../../components/HelpDrawer";
@@ -78,10 +79,8 @@ export const PlainTextCard = ({ title, value }: { title: string, value: string }
 
 const GrantRecipesDetailPage: React.FC = () => {
   const { id } = useParams<string>();
-
   const notifications = useNotifications();
   const navigate = useNavigate();
-
   const { loading, setLoading } = useContext(LoadingContext);
   const [recipe, setRecipe] = useState<GrantRecipe>({ id: 'test', description: 'test' } as GrantRecipe);
   const [lastUpdated, setLastUpdated] = useState<string>("");
@@ -89,6 +88,8 @@ const GrantRecipesDetailPage: React.FC = () => {
   const { showHelp } = useHelp();
   const [helpTopic, setHelpTopic] = useState<string | undefined>();
   const [isValid, setIsValid] = useState<boolean>(false);
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
     setIsValid((recipe?.description ?? "").trim().length > 0);
@@ -196,6 +197,31 @@ const GrantRecipesDetailPage: React.FC = () => {
       })
   }
 
+  const handleDeleteClick = () => {
+    setOpenDeleteDialog(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!recipe || !recipe.id) return;
+
+    try {
+      setIsDeleting(true);
+      await grantRecipeService.delete(recipe.id);
+      notifications.success("Recipe deleted successfully");
+      setOpenDeleteDialog(false);
+      navigate('/grant-recipes');
+    } catch (error) {
+      console.error('Failed to delete recipe:', error);
+      notifications.error("Failed to delete recipe. Please try again.");
+      setOpenDeleteDialog(false);
+      setIsDeleting(false);
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    setOpenDeleteDialog(false);
+  };
+
   return (recipe &&
     <>
       <LoadingOverlay />
@@ -250,7 +276,48 @@ const GrantRecipesDetailPage: React.FC = () => {
                       <Button variant="contained" disabled={loading || !isValid} onClick={() => handleClone()}>Clone</Button>
                       <Divider orientation="vertical" />
                       <Button variant="contained" disabled={loading || !dirty || !isValid} onClick={() => saveRecipe()}>Save</Button>
+                      <Button
+                        variant="outlined"
+                        color="error"
+                        startIcon={<DeleteIcon />}
+                        onClick={handleDeleteClick}
+                        disabled={isDeleting}
+                      >
+                        Delete
+                      </Button>
                     </CardActions>
+
+                    {/* Delete Confirmation Dialog */}
+                    <Dialog
+                      open={openDeleteDialog}
+                      onClose={handleDeleteCancel}
+                      aria-labelledby="alert-dialog-title"
+                      aria-describedby="alert-dialog-description"
+                    >
+                      <DialogTitle id="alert-dialog-title">
+                        Delete Recipe?
+                      </DialogTitle>
+                      <DialogContent>
+                        <DialogContentText id="alert-dialog-description">
+                          Are you sure you want to delete "<strong>{recipe?.description}</strong>"? 
+                          This action cannot be undone. Any proposals generated from this recipe will remain, 
+                          but they won't be able to regenerate.
+                        </DialogContentText>
+                      </DialogContent>
+                      <DialogActions>
+                        <Button onClick={handleDeleteCancel} disabled={isDeleting}>
+                          Cancel
+                        </Button>
+                        <Button
+                          onClick={handleDeleteConfirm}
+                          color="error"
+                          variant="contained"
+                          disabled={isDeleting}
+                        >
+                          {isDeleting ? 'Deleting...' : 'Delete'}
+                        </Button>
+                      </DialogActions>
+                    </Dialog>
                   </Card>
                 </Stack>
                 }

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -213,12 +213,15 @@ const GrantRecipesDetailPage: React.FC = () => {
       console.error('Failed to delete recipe:', error);
       notifications.error("Failed to delete recipe. Please try again.");
       setOpenDeleteDialog(false);
+    } finally {
       setIsDeleting(false);
     }
   };
 
   const handleDeleteCancel = () => {
-    setOpenDeleteDialog(false);
+    if (!isDeleting) {
+      setOpenDeleteDialog(false);
+    }
   };
 
   return (recipe &&
@@ -280,7 +283,7 @@ const GrantRecipesDetailPage: React.FC = () => {
                       color="error"
                       startIcon={<DeleteIcon />}
                       onClick={handleDeleteClick}
-                      disabled={isDeleting}
+                      disabled={loading || isDeleting}
                     >
                       Delete
                     </Button>
@@ -289,7 +292,11 @@ const GrantRecipesDetailPage: React.FC = () => {
                   {/* Delete Confirmation Dialog */}
                   <Dialog
                     open={openDeleteDialog}
-                    onClose={handleDeleteCancel}
+                    onClose={(event, reason) => {
+                      if (reason === 'backdropClick' && isDeleting) return;
+                      handleDeleteCancel();
+                    }}
+                    disableEscapeKeyDown={isDeleting}
                     aria-labelledby="alert-dialog-title"
                     aria-describedby="alert-dialog-description"
                   >


### PR DESCRIPTION
##WAVE 136

- Add delete button to recipe detail page CardActions
- Show confirmation dialogue before deletion
- Redirect to recipes list after successful deletion

## Description

Currently, users cannot delete a Grant Recipe once they are inside the Grant Recipe Detail page. This forces them to navigate elsewhere or prevents removal entirely, creating a friction point in managing recipes.

Add a Delete button on the Grant Recipe Detail page that allows users to delete the recipe directly from the detail view. Include a confirmation step to prevent accidental deletion.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update