### PR TITLE
Wave-126: fix(grants): restrict header checkbox selection to current …

### DIFF
--- a/src/pages/grants/GrantProposalsListPage.tsx
+++ b/src/pages/grants/GrantProposalsListPage.tsx
@@ -1,14 +1,16 @@
 import { DeleteOutlined, HomeOutlined } from "@ant-design/icons";
 import { LoadingContext, useNotifications } from "@digitalaidseattle/core";
 import {
-  Box, Breadcrumbs, Card, CardContent, CardHeader,
+  Box, Breadcrumbs, Button, Card, CardContent, CardHeader,
   IconButton, Toolbar, Tooltip, Typography
 } from "@mui/material";
 import {
   DataGrid,
   GridColDef,
   GridRowParams,
-  GridRowSelectionModel
+  GridRowSelectionModel,
+  gridPaginatedVisibleSortedGridRowIdsSelector,
+  useGridApiRef,
 } from "@mui/x-data-grid";
 import { useContext, useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
@@ -23,8 +25,10 @@ const GrantProposalsListPage: React.FC = () => {
   const navigate = useNavigate();
   const { loading, setLoading } = useContext(LoadingContext);
 
+  const apiRef = useGridApiRef();
   const [proposals, setProposals] = useState<GrantProposal[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
 
   useEffect(() => {
     fetchProposals();
@@ -72,16 +76,31 @@ const GrantProposalsListPage: React.FC = () => {
   };
 
   function handleRowSelection(model: GridRowSelectionModel) {
-    if (model) {
-      if (model.type === "include") {
-        setSelectedIds([...model.ids as unknown as string[]]);
-      } else {
-        const selected = proposals
-          .map(elem => elem.id as string)
-          .filter(id => !model.ids.has(id));
-        setSelectedIds(selected);
-      }
+    if (!model) return;
+
+    if (model.type === "include") {
+      // Individual row toggles — MUI owns the checkbox state, just sync our copy
+      setSelectedIds([...model.ids as unknown as string[]]);
+    } else {
+      // Header "select all" checkbox fired — restrict to current page only
+      const currentPageIds = gridPaginatedVisibleSortedGridRowIdsSelector(apiRef) as string[];
+      const pageOnlyIds = currentPageIds.filter(id => !model.ids.has(id));
+
+      // If all page rows were already selected, the user clicked the header to DESELECT
+      const allPageAlreadySelected =
+        currentPageIds.length > 0 &&
+        currentPageIds.every(id => selectedIds.includes(id));
+      const finalIds = allPageAlreadySelected ? [] : pageOnlyIds;
+
+      setSelectedIds(finalIds);
+      apiRef.current?.setRowSelectionModel({ type: "include", ids: new Set(finalIds) });
     }
+  }
+
+  function handleSelectAllRecords() {
+    const allIds = proposals.map(p => p.id as string);
+    setSelectedIds(allIds);
+    apiRef.current?.setRowSelectionModel({ type: "include", ids: new Set(allIds) });
   }
 
   const columns: GridColDef<GrantProposal>[] = [
@@ -112,6 +131,18 @@ const GrantProposalsListPage: React.FC = () => {
   function CustomToolbar() {
     return (
       <Toolbar sx={{ gap: 2, backgroundColor: 'background.default' }}>
+        <Tooltip title={`Select all ${proposals.length} proposals`}>
+          <span>
+            <Button
+              size="small"
+              variant="text"
+              onClick={handleSelectAllRecords}
+              disabled={proposals.length === 0}
+            >
+              Select All ({proposals.length})
+            </Button>
+          </span>
+        </Tooltip>
         <Tooltip title="Delete Recipes">
           <Box>
             <IconButton color="error"
@@ -136,6 +167,7 @@ const GrantProposalsListPage: React.FC = () => {
         <CardHeader title="Grant Proposals" />
         <CardContent>
           <DataGrid
+            apiRef={apiRef}
             rows={proposals}
             columns={columns}
             loading={loading}
@@ -150,15 +182,16 @@ const GrantProposalsListPage: React.FC = () => {
             checkboxSelection={true}
             onRowSelectionModelChange={handleRowSelection}
 
+            paginationModel={paginationModel}
+            onPaginationModelChange={(model) => {
+              setPaginationModel(model);
+            }}
+            pageSizeOptions={[10, 25, 50]}
             initialState={{
-              pagination: {
-                paginationModel: { pageSize: 10 },
-              },
               sorting: {
                 sortModel: [{ field: 'updatedAt', sort: 'desc' }],
               },
             }}
-            pageSizeOptions={[10, 25, 50]}
             disableRowSelectionOnClick
             sx={{
               width: '100%',

--- a/src/pages/grants/GrantRecipesListPage.tsx
+++ b/src/pages/grants/GrantRecipesListPage.tsx
@@ -1,6 +1,6 @@
 import { CopyOutlined, DeleteOutlined, HomeOutlined, PlusCircleOutlined } from "@ant-design/icons";
-import { Box, Breadcrumbs, Card, CardContent, CardHeader, Chip, IconButton, Toolbar, Tooltip, Typography } from "@mui/material";
-import { DataGrid, GridColDef, GridRowParams, GridRowSelectionModel } from "@mui/x-data-grid";
+import { Box, Breadcrumbs, Button, Card, CardContent, CardHeader, Chip, IconButton, Toolbar, Tooltip, Typography } from "@mui/material";
+import { DataGrid, GridColDef, GridRowParams, GridRowSelectionModel, gridPaginatedVisibleSortedGridRowIdsSelector, useGridApiRef } from "@mui/x-data-grid";
 import { useContext, useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 
@@ -16,8 +16,10 @@ const GrantRecipesListPage: React.FC = () => {
   const notifications = useNotifications();
   const navigate = useNavigate();
   const { loading, setLoading } = useContext(LoadingContext);
+  const apiRef = useGridApiRef();
   const [recipes, setRecipes] = useState<GrantRecipe[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
 
   useEffect(() => {
     fetchRecipes();
@@ -82,16 +84,31 @@ const GrantRecipesListPage: React.FC = () => {
   }
 
   function handleRowSelection(model: GridRowSelectionModel) {
-    if (model) {
-      if (model.type === "include") {
-        setSelectedIds([...model.ids as unknown as string[]]);
-      } else {
-        const selected = recipes
-          .map(elem => elem.id as string)
-          .filter(id => !model.ids.has(id));
-        setSelectedIds(selected);
-      }
+    if (!model) return;
+
+    if (model.type === "include") {
+      // Individual row toggles — MUI owns the checkbox state, just sync our copy
+      setSelectedIds([...model.ids as unknown as string[]]);
+    } else {
+      // Header "select all" checkbox fired — restrict to current page only
+      const currentPageIds = gridPaginatedVisibleSortedGridRowIdsSelector(apiRef) as string[];
+      const pageOnlyIds = currentPageIds.filter(id => !model.ids.has(id));
+
+      // If all page rows were already selected, the user clicked the header to DESELECT
+      const allPageAlreadySelected =
+        currentPageIds.length > 0 &&
+        currentPageIds.every(id => selectedIds.includes(id));
+      const finalIds = allPageAlreadySelected ? [] : pageOnlyIds;
+
+      setSelectedIds(finalIds);
+      apiRef.current?.setRowSelectionModel({ type: "include", ids: new Set(finalIds) });
     }
+  }
+
+  function handleSelectAllRecords() {
+    const allIds = recipes.map(r => r.id as string);
+    setSelectedIds(allIds);
+    apiRef.current?.setRowSelectionModel({ type: "include", ids: new Set(allIds) });
   }
 
   const columns: GridColDef<GrantRecipe>[] = [
@@ -138,6 +155,18 @@ const GrantRecipesListPage: React.FC = () => {
   function CustomToolbar() {
     return (
       <Toolbar sx={{ gap: 2, backgroundColor: 'background.default' }}>
+        <Tooltip title={`Select all ${recipes.length} recipes`}>
+          <span>
+            <Button
+              size="small"
+              variant="text"
+              onClick={handleSelectAllRecords}
+              disabled={recipes.length === 0}
+            >
+              Select All ({recipes.length})
+            </Button>
+          </span>
+        </Tooltip>
         <Tooltip title="Add Recipe">
           <Box>
             <IconButton color="primary"
@@ -179,6 +208,7 @@ const GrantRecipesListPage: React.FC = () => {
         <CardHeader title="Grant Recipes" />
         <CardContent>
           <DataGrid
+            apiRef={apiRef}
             rows={recipes}
             columns={columns}
             loading={loading}
@@ -193,16 +223,17 @@ const GrantRecipesListPage: React.FC = () => {
             checkboxSelection={true}
             onRowSelectionModelChange={handleRowSelection}
 
+            paginationModel={paginationModel}
+            onPaginationModelChange={(model) => {
+              setPaginationModel(model);
+            }}
+
+            pageSizeOptions={[10, 25, 50]}
             initialState={{
-              pagination: {
-                paginationModel: { pageSize: 10 },
-              },
               sorting: {
                 sortModel: [{ field: 'updatedAt', sort: 'desc' }],
               },
             }}
-
-            pageSizeOptions={[10, 25, 50]}
             disableRowSelectionOnClick
             sx={{
               width: '100%',


### PR DESCRIPTION
## Description

When I clicked the master checkbox in the table header, the system selects all 68 records in the database rather than the 10 records currently displayed on the page.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Expected Behaviour

The system should only select the 10 rows visible on the current page  to prevent accidental batch deletions. If a global selection is intended, a secondary prompt should appear for example,: "All 10 rows on this page are selected. Select all 68 proposals?".
