### PR TITLE
WAVE 153 - Rename proposal to recipe on dashboard page.

### DIFF
--- a/src/constants/dashboard.ts
+++ b/src/constants/dashboard.ts
@@ -1,0 +1,7 @@
+export const DASHBOARD_STRINGS = {
+  recentRecipes: "Recent Recipes",
+  cloneRecipe: "Clone Recipe",
+  selectRecentRecipe: "Select a recent Recipe",
+  newRecipe: "New Recipe",
+  noProposals: "No proposals yet",
+};

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -29,6 +29,7 @@ import { GrantRecipe } from '../../types';
 import { LoadingContext } from '@digitalaidseattle/core';
 import LoadingButton from '../../components/LoadingButton';
 import { DateUtils } from '../../utils/dateUtils';
+import { DASHBOARD_STRINGS } from '../../constants/dashboard';
 
 const RecentRecipesCard = () => {
   const navigate = useNavigate();
@@ -49,7 +50,7 @@ const RecentRecipesCard = () => {
   return (
     <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <CardHeader 
-        title="Recent Recipes" 
+        title={DASHBOARD_STRINGS.recentRecipes} 
         titleTypographyProps={{ variant: 'h6', fontWeight: 600 }}
       />
       <CardContent sx={{ flex: 1, overflow: 'auto', p: 0 }}>
@@ -70,7 +71,7 @@ const RecentRecipesCard = () => {
                 }}
               >
                 <ListItemText
-                  primary={recipe.description || 'Untitled Recipe'}
+                  primary={recipe.description}
                   primaryTypographyProps={{ variant: 'body2', fontWeight: 500 }}
                   secondary={recipe.updatedAt ? DateUtils.formatDateTime(recipe.updatedAt) : 'Unknown date'}
                   secondaryTypographyProps={{ variant: 'caption' }}
@@ -81,7 +82,7 @@ const RecentRecipesCard = () => {
         ) : (
           <Stack alignItems="center" justifyContent="center" sx={{ py: 4, px: 2 }}>
             <Typography color="textSecondary" align="center">
-              No proposals yet
+              {DASHBOARD_STRINGS.noProposals}
             </Typography>
           </Stack>
         )}
@@ -113,9 +114,9 @@ const CloneRecipeCard = () => {
 
   return (
     <Card>
-      <CardHeader title="Clone Recipe" />
+      <CardHeader title={DASHBOARD_STRINGS.cloneRecipe} />
       <CardContent>
-        <Typography>Select a recent Recipe</Typography>
+        <Typography>{DASHBOARD_STRINGS.selectRecentRecipe}</Typography>
         <Select
           fullWidth={true}
           value={selectedRecipe ? selectedRecipe.id : ''}
@@ -144,7 +145,7 @@ const CreateRecipeCard = () => {
 
   return (
     <Card>
-      <CardHeader title="New Recipe" />
+      <CardHeader title={DASHBOARD_STRINGS.newRecipe} />
       <CardActions>
         <LoadingButton
           variant="contained"

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -49,7 +49,7 @@ const RecentRecipesCard = () => {
   return (
     <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <CardHeader 
-        title="Recent Proposals" 
+        title="Recent Recipes" 
         titleTypographyProps={{ variant: 'h6', fontWeight: 600 }}
       />
       <CardContent sx={{ flex: 1, overflow: 'auto', p: 0 }}>
@@ -70,7 +70,7 @@ const RecentRecipesCard = () => {
                 }}
               >
                 <ListItemText
-                  primary={recipe.description || 'Untitled Proposal'}
+                  primary={recipe.description || 'Untitled Recipe'}
                   primaryTypographyProps={{ variant: 'body2', fontWeight: 500 }}
                   secondary={recipe.updatedAt ? DateUtils.formatDateTime(recipe.updatedAt) : 'Unknown date'}
                   secondaryTypographyProps={{ variant: 'caption' }}
@@ -113,9 +113,9 @@ const CloneRecipeCard = () => {
 
   return (
     <Card>
-      <CardHeader title="Clone Proposal" />
+      <CardHeader title="Clone Recipe" />
       <CardContent>
-        <Typography>Select a recent Proposal</Typography>
+        <Typography>Select a recent Recipe</Typography>
         <Select
           fullWidth={true}
           value={selectedRecipe ? selectedRecipe.id : ''}
@@ -144,7 +144,7 @@ const CreateRecipeCard = () => {
 
   return (
     <Card>
-      <CardHeader title="New Proposal" />
+      <CardHeader title="New Recipe" />
       <CardActions>
         <LoadingButton
           variant="contained"


### PR DESCRIPTION
## Description
 Rename "Praposal" to "Recipe" on dashboard page

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## QA Instructions

- Check the Dashboard Page - Name changed from 
   ""New Praposal" -> "New Recipe" 
   "Clone Praposal" ->  "Clone Recipe" 
   "Recent Praposal" ->  "Recent Recipe" 
   "Select a recent praposal" ->  "Select a recent recipe" 
   

