### PR TITLE
Feature/add delete proposal

### DIFF
--- a/src/pages/grants/GrantProposalsDetailPage.tsx
+++ b/src/pages/grants/GrantProposalsDetailPage.tsx
@@ -177,8 +177,19 @@ const GrantProposalsDetailPage: React.FC = () => {
       </Breadcrumbs>
       {!proposal && <Typography>No proposal data found.</Typography>}
       {proposal &&
-        <Stack spacing={2}>
-          <Card>
+        <Stack
+          sx={{
+            height: "calc(100dvh - 112px)",
+            gap: 2,
+          }}
+        >
+          <Card
+            sx={{
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
             <CardHeader title={<TextEdit
               value={proposal.name ? proposal.name : "Grant Proposal Detail"}
               onChange={handleNameChange} />}
@@ -188,6 +199,29 @@ const GrantProposalsDetailPage: React.FC = () => {
                 <Typography component="span">; Total token count: {proposal.totalTokenCount ?? "N/A"}</Typography>
               </>}
               action={<Clipboard text={Object.values(proposal.structuredResponse!).join('\n')} />} />
+            <CardContent
+              sx={{
+                flex: 1,
+                overflowY: "auto",
+              }}
+            >
+              <Stack spacing={2}>
+                {reponses.map((response) => {
+                  return (
+                    <Card key={response.name} variant="outlined">
+                      <CardHeader
+                        title={response.name}
+                        subheader={response.subheader}
+                        action={<Tooltip title="Copies this section of the proposal into clipboard."><Box><Clipboard text={response.value} /></Box></Tooltip>}
+                      />
+                      <CardContent>
+                        <Markdown>{response.value}</Markdown>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </Stack>
+            </CardContent>
             <CardActions
               sx={{
                 borderTop: "1px solid",
@@ -205,20 +239,6 @@ const GrantProposalsDetailPage: React.FC = () => {
               </Button>
             </CardActions>
           </Card>
-          {reponses.map((response) => {
-            return (
-              <Card key={response.name} variant="outlined">
-                <CardHeader
-                  title={response.name}
-                  subheader={response.subheader}
-                  action={<Tooltip title="Copies this section of the proposal into clipboard."><Box><Clipboard text={response.value} /></Box></Tooltip>}
-                />
-                <CardContent>
-                  <Markdown>{response.value}</Markdown>
-                </CardContent>
-              </Card>
-            );
-          })}
         </Stack>
       }
       <ConfirmationDialog

--- a/src/pages/grants/GrantProposalsDetailPage.tsx
+++ b/src/pages/grants/GrantProposalsDetailPage.tsx
@@ -4,12 +4,13 @@
  * @copyright 2026 Digital Aid Seattle
 */
 import { HomeOutlined } from "@ant-design/icons";
-import { Box, Breadcrumbs, Card, CardContent, CardHeader, IconButton, Stack, Tooltip, Typography } from "@mui/material";
+import { LoadingContext, useNotifications } from "@digitalaidseattle/core";
+import { Clipboard, ConfirmationDialog } from "@digitalaidseattle/mui";
+import { Box, Breadcrumbs, Button, Card, CardActions, CardContent, CardHeader, IconButton, Stack, Tooltip, Typography } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
 import { useContext, useEffect, useMemo, useState } from "react";
-import { NavLink, useParams } from "react-router-dom";
+import { NavLink, useNavigate, useParams } from "react-router-dom";
 
-import { LoadingContext } from "@digitalaidseattle/core";
-import { Clipboard } from "@digitalaidseattle/mui";
 import Markdown from "react-markdown";
 import { LoadingOverlay } from "../../components/LoadingOverlay";
 import { TextEdit } from "../../components/TextEdit";
@@ -28,12 +29,16 @@ function countCharacters(text: string): number {
 }
 
 const GrantProposalsDetailPage: React.FC = () => {
-  const { setLoading } = useContext(LoadingContext);
+  const notifications = useNotifications();
+  const navigate = useNavigate();
+  const { loading, setLoading } = useContext(LoadingContext);
   const { id } = useParams<{ id: string }>();
 
   const [proposal, setProposal] = useState<GrantProposal | null>(null);
   const [recipe, setRecipe] = useState<GrantRecipe | null>(null);
   const [outputs, setOutputs] = useState<GrantOutput[]>([]);
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -129,6 +134,57 @@ const GrantProposalsDetailPage: React.FC = () => {
     }
   }
 
+  const handleDeleteClick = () => {
+    setOpenDeleteDialog(true);
+  };
+
+  const handleDeleteCancel = () => {
+    if (!isDeleting) {
+      setOpenDeleteDialog(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!proposal?.id) return;
+
+    const proposalId = String(proposal.id);
+    const recipeId = proposal.grantRecipeId ? String(proposal.grantRecipeId) : "";
+
+    try {
+      setLoading(true);
+      setIsDeleting(true);
+
+      await grantProposalService.delete(proposalId);
+
+      if (recipeId.trim() !== "") {
+        try {
+          const parentRecipe = recipe ?? await grantRecipeService.getById(recipeId);
+          const nextProposalIds = (parentRecipe.proposalIds ?? []).filter((id) => id !== proposalId);
+
+          if (nextProposalIds.length !== (parentRecipe.proposalIds ?? []).length) {
+            await grantRecipeService.update(parentRecipe.id as string, {
+              ...parentRecipe,
+              proposalIds: nextProposalIds,
+            });
+          }
+        } catch (cleanupError) {
+          console.warn("Proposal deleted but recipe reference cleanup failed:", cleanupError);
+        }
+      }
+
+      notifications.success("Proposal deleted successfully");
+      setOpenDeleteDialog(false);
+      navigate("/grant-proposals");
+    } catch (error) {
+      console.error("Failed to delete proposal:", error);
+      notifications.error("Failed to delete proposal. Please try again.");
+      setOpenDeleteDialog(false);
+    } finally {
+      setIsDeleting(false);
+      setLoading(false);
+    }
+  };
+
   return (
     <>
       <LoadingOverlay />
@@ -150,6 +206,22 @@ const GrantProposalsDetailPage: React.FC = () => {
                 <Typography component="span">; Total token count: {proposal.totalTokenCount ?? "N/A"}</Typography>
               </>}
               action={<Clipboard text={Object.values(proposal.structuredResponse!).join('\n')} />} />
+            <CardActions
+              sx={{
+                borderTop: "1px solid",
+                borderColor: "divider",
+                justifyContent: "flex-end",
+              }}>
+              <Button
+                variant="outlined"
+                color="error"
+                startIcon={<DeleteIcon />}
+                onClick={handleDeleteClick}
+                disabled={loading || isDeleting}
+              >
+                Delete
+              </Button>
+            </CardActions>
           </Card>
           {reponses.map((response) => {
             return (
@@ -167,6 +239,13 @@ const GrantProposalsDetailPage: React.FC = () => {
           })}
         </Stack>
       }
+      <ConfirmationDialog
+        title="Delete Proposal?"
+        message={`Are you sure you want to delete "${proposal?.name || "this proposal"}"? This action cannot be undone.`}
+        open={openDeleteDialog}
+        handleConfirm={handleDeleteConfirm}
+        handleCancel={handleDeleteCancel}
+      />
     </>
   );
 };

--- a/src/pages/grants/GrantProposalsDetailPage.tsx
+++ b/src/pages/grants/GrantProposalsDetailPage.tsx
@@ -16,6 +16,7 @@ import { LoadingOverlay } from "../../components/LoadingOverlay";
 import { TextEdit } from "../../components/TextEdit";
 import { grantProposalService } from "../../services/grantProposalService";
 import { grantRecipeService } from "../../services/grantRecipeService";
+import { deleteProposal } from "../../transactions/DeleteProposal";
 import type { GrantOutput, GrantProposal, GrantRecipe } from "../../types";
 import { DateUtils } from "../../utils/dateUtils";
 
@@ -147,30 +148,11 @@ const GrantProposalsDetailPage: React.FC = () => {
   const handleDeleteConfirm = async () => {
     if (!proposal?.id) return;
 
-    const proposalId = String(proposal.id);
-    const recipeId = proposal.grantRecipeId ? String(proposal.grantRecipeId) : "";
-
     try {
       setLoading(true);
       setIsDeleting(true);
 
-      await grantProposalService.delete(proposalId);
-
-      if (recipeId.trim() !== "") {
-        try {
-          const parentRecipe = recipe ?? await grantRecipeService.getById(recipeId);
-          const nextProposalIds = (parentRecipe.proposalIds ?? []).filter((id) => id !== proposalId);
-
-          if (nextProposalIds.length !== (parentRecipe.proposalIds ?? []).length) {
-            await grantRecipeService.update(parentRecipe.id as string, {
-              ...parentRecipe,
-              proposalIds: nextProposalIds,
-            });
-          }
-        } catch (cleanupError) {
-          console.warn("Proposal deleted but recipe reference cleanup failed:", cleanupError);
-        }
-      }
+      await deleteProposal(proposal, recipe);
 
       notifications.success("Proposal deleted successfully");
       setOpenDeleteDialog(false);

--- a/src/pages/grants/GrantProposalsDetailPage.tsx
+++ b/src/pages/grants/GrantProposalsDetailPage.tsx
@@ -68,12 +68,13 @@ const GrantProposalsDetailPage: React.FC = () => {
 
   useEffect(() => {
     if (!id) return;
+    const proposalId = id;
 
     async function fetchData() {
       setLoading(true);
 
       try {
-        const proposalData = await grantProposalService.getById(id);
+        const proposalData = await grantProposalService.getById(proposalId);
         setProposal(proposalData);
 
         const recipeId = proposalData?.grantRecipeId;

--- a/src/pages/grants/GrantProposalsListPage.tsx
+++ b/src/pages/grants/GrantProposalsListPage.tsx
@@ -16,7 +16,8 @@ import { useContext, useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { LoadingOverlay } from "../../components/LoadingOverlay";
 import { grantProposalService } from "../../services/grantProposalService";
-import type { GrantProposal } from "../../types";
+import { deleteProposal } from "../../transactions/DeleteProposal";
+import type { GrantProposal, Timestamp } from "../../types";
 import { DateUtils } from "../../utils/dateUtils";
 
 const GrantProposalsListPage: React.FC = () => {
@@ -29,6 +30,10 @@ const GrantProposalsListPage: React.FC = () => {
   const [proposals, setProposals] = useState<GrantProposal[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
+
+  function getCreatedAtSortValue(createdAt: GrantProposal["createdAt"]): number {
+    return createdAt instanceof Date ? createdAt.getTime() : (createdAt as Timestamp).seconds;
+  }
 
   useEffect(() => {
     fetchProposals();
@@ -57,8 +62,12 @@ const GrantProposalsListPage: React.FC = () => {
     }
 
     setLoading(true);
+    const selectedProposals = proposals.filter((proposal) => {
+      return proposal.id != null && selectedIds.includes(String(proposal.id));
+    });
+
     Promise
-      .all(selectedIds.map(id => grantProposalService.delete(id)))
+      .all(selectedProposals.map((proposal) => deleteProposal(proposal)))
       .then(() => {
         fetchProposals();
         notifications.success("Proposals deleted!")
@@ -124,7 +133,7 @@ const GrantProposalsListPage: React.FC = () => {
       headerName: "Last Updated",
       width: 180,
       renderCell: (params) => <Typography>{DateUtils.formatDateTime(params.row.createdAt)}</Typography>,
-      valueGetter: (_value, row) => (row.createdAt as any).seconds,
+      valueGetter: (_value, row) => getCreatedAtSortValue(row.createdAt),
     }
   ];
 

--- a/src/services/ProposalExporter.ts
+++ b/src/services/ProposalExporter.ts
@@ -4,8 +4,6 @@
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import { saveAs } from "file-saver";
-
 import { GrantProposal } from "../types";
 
 abstract class AbstractExporter {
@@ -14,7 +12,12 @@ abstract class AbstractExporter {
         const type = this.getApplicationType()
         const extension = this.getDownloadExtension()
         const blob = new Blob([data], { type: type });
-        saveAs(blob, `${proposal.name}.${extension}`);
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${proposal.name}.${extension}`;
+        link.click();
+        URL.revokeObjectURL(url);
     }
     abstract getApplicationType(): string;
     abstract getDownloadExtension(): string;

--- a/src/transactions/DeleteProposal.test.ts
+++ b/src/transactions/DeleteProposal.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GrantProposal, GrantRecipe } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  deleteMock: vi.fn(),
+  getByIdMock: vi.fn(),
+  updateMock: vi.fn(),
+}));
+
+vi.mock("../services/grantProposalService", () => ({
+  grantProposalService: {
+    delete: mocks.deleteMock,
+  },
+}));
+
+vi.mock("../services/grantRecipeService", () => ({
+  grantRecipeService: {
+    getById: mocks.getByIdMock,
+    update: mocks.updateMock,
+  },
+}));
+
+import { deleteProposal } from "./DeleteProposal";
+
+describe("deleteProposal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes the proposal and removes its id from the parent recipe", async () => {
+    const recipe: GrantRecipe = {
+      id: "recipe-123",
+      createdAt: new Date(),
+      createdBy: "tester@example.com",
+      updatedAt: new Date(),
+      updatedBy: "tester@example.com",
+      lastSubmitted: null,
+      description: "Recipe",
+      tags: [],
+      rating: 0,
+      template: "",
+      prompt: "",
+      contexts: [],
+      outputsWithWordCount: [],
+      inputParameters: [],
+      tokenCount: 0,
+      proposalIds: ["proposal-1", "proposal-2"],
+      modelType: "gemini-2.5-flash",
+    };
+
+    mocks.deleteMock.mockResolvedValue(undefined);
+    mocks.updateMock.mockResolvedValue({ ...recipe, proposalIds: ["proposal-2"] });
+
+    await deleteProposal(
+      {
+        id: "proposal-1",
+        grantRecipeId: "recipe-123",
+      } as GrantProposal,
+      recipe
+    );
+
+    expect(mocks.deleteMock).toHaveBeenCalledWith("proposal-1");
+    expect(mocks.getByIdMock).not.toHaveBeenCalled();
+    expect(mocks.updateMock).toHaveBeenCalledWith("recipe-123", {
+      ...recipe,
+      proposalIds: ["proposal-2"],
+    });
+  });
+
+  it("fetches the recipe when one is not provided", async () => {
+    const recipe: GrantRecipe = {
+      id: "recipe-123",
+      createdAt: new Date(),
+      createdBy: "tester@example.com",
+      updatedAt: new Date(),
+      updatedBy: "tester@example.com",
+      lastSubmitted: null,
+      description: "Recipe",
+      tags: [],
+      rating: 0,
+      template: "",
+      prompt: "",
+      contexts: [],
+      outputsWithWordCount: [],
+      inputParameters: [],
+      tokenCount: 0,
+      proposalIds: ["proposal-1"],
+      modelType: "gemini-2.5-flash",
+    };
+
+    mocks.deleteMock.mockResolvedValue(undefined);
+    mocks.getByIdMock.mockResolvedValue(recipe);
+    mocks.updateMock.mockResolvedValue({ ...recipe, proposalIds: [] });
+
+    await deleteProposal({
+      id: "proposal-1",
+      grantRecipeId: "recipe-123",
+    } as GrantProposal);
+
+    expect(mocks.getByIdMock).toHaveBeenCalledWith("recipe-123");
+    expect(mocks.updateMock).toHaveBeenCalledWith("recipe-123", {
+      ...recipe,
+      proposalIds: [],
+    });
+  });
+
+  it("skips recipe cleanup when the proposal has no recipe id", async () => {
+    mocks.deleteMock.mockResolvedValue(undefined);
+
+    await deleteProposal({
+      id: "proposal-1",
+      grantRecipeId: "",
+    } as GrantProposal);
+
+    expect(mocks.deleteMock).toHaveBeenCalledWith("proposal-1");
+    expect(mocks.getByIdMock).not.toHaveBeenCalled();
+    expect(mocks.updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/transactions/DeleteProposal.ts
+++ b/src/transactions/DeleteProposal.ts
@@ -1,0 +1,35 @@
+import { grantProposalService } from "../services/grantProposalService";
+import { grantRecipeService } from "../services/grantRecipeService";
+import type { GrantProposal, GrantRecipe } from "../types";
+
+export async function deleteProposal(
+  proposal: Pick<GrantProposal, "id" | "grantRecipeId">,
+  recipe?: GrantRecipe | null
+): Promise<void> {
+  if (!proposal.id) {
+    throw new Error("Proposal ID is required");
+  }
+
+  const proposalId = String(proposal.id);
+  const recipeId = proposal.grantRecipeId ? String(proposal.grantRecipeId) : "";
+
+  await grantProposalService.delete(proposalId);
+
+  if (recipeId.trim() === "") {
+    return;
+  }
+
+  try {
+    const parentRecipe = recipe ?? await grantRecipeService.getById(recipeId);
+    const nextProposalIds = (parentRecipe.proposalIds ?? []).filter((id) => id !== proposalId);
+
+    if (nextProposalIds.length !== (parentRecipe.proposalIds ?? []).length) {
+      await grantRecipeService.update(parentRecipe.id as string, {
+        ...parentRecipe,
+        proposalIds: nextProposalIds,
+      });
+    }
+  } catch (error) {
+    console.warn("Proposal deleted but recipe reference cleanup failed:", error);
+  }
+}


### PR DESCRIPTION
## Description

  This PR adds a Delete button to the Grant Proposal detail page so users can remove a proposal
  directly from that view without navigating away first. The flow includes a confirmation dialog,
  deletes the proposal on confirm, and redirects the user back to the Grant Proposals list.

  Proposal deletion is now routed through a shared cleanup path. Once proposal IDs are linked on
  recipes via `proposalIds`, deleting a proposal will also remove that linked ID from the parent
  recipe. The same cleanup logic is reused from the Grant Proposals list page so deletion
  behavior stays consistent across both entry points and prevents orphaned references.

  ## What type of PR is this? (check all applicable)

  - [ ] Refactor
  - [x] Feature
  - [ ] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  ## Related Tickets & Documents

https://digital-aid-seattle.atlassian.net/browse/WAVE-140

  1. Open any existing Grant Proposal detail page.
  2. Verify a `Delete` button is visible on the page.
  3. Verify the button styling matches the delete button on the Grant Recipe detail page.
  4. Click `Delete`.
  5. Verify a confirmation dialog appears asking to confirm deletion of the proposal.
  6. Click `Cancel`.
  7. Verify the dialog closes and the proposal remains unchanged.
  8. Click `Delete` again and confirm deletion.
  9. Verify the proposal is deleted successfully and the app redirects to `/grant-proposals`.
  10. Verify the deleted proposal no longer appears in the Grant Proposals list.
  11. From the Grant Proposals list page, delete one or more proposals and verify the same delete
  behavior works there as well.
  12. If recipe `proposalIds` links are populated in the environment, verify deleting a proposal
  also removes its ID from the parent recipe so no orphaned references remain.