### PR TITLE
feat(WAVE 99): update Recipe Detail UI terminology with user-friendly labels

### DIFF
--- a/src/constants/grantRecipe.ts
+++ b/src/constants/grantRecipe.ts
@@ -1,0 +1,10 @@
+export const RECIPE_STRINGS = {
+  infoTitle: "Info",
+  recipeTitle: "Recipe Title",
+  templateTitle: "What would you like the grant writer to create?",
+  projectContextsTitle: "Project Contexts",
+  projectContextsSubtext: "Upload documents or paste text that provide helpful context, such as past proposals, project descriptions, budgets, or notes.",
+  outputFieldsTitle: "Output Fields",
+  outputFieldsSubtext: "Add the questions or sections from the grant application that you want the grant writer to answer.",
+  promptTitle: "Prompt (system-generated)",
+};

--- a/src/pages/grants/GrantContextEditor.tsx
+++ b/src/pages/grants/GrantContextEditor.tsx
@@ -17,6 +17,7 @@ import { StableCursorTextField } from '../../components/StableCursorTextfield';
 import { StorageFile } from '../../services/OurWaveStorageService';
 import { GrantContext, GrantRecipe } from '../../types';
 import { GrantAiService } from './grantAiService';
+import { RECIPE_STRINGS } from '../../constants/grantRecipe';
 
 const SUPPORTED_FILE_TYPES = [
     "text/plain",
@@ -140,7 +141,8 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
 
     return (
         <Card>
-            <CardHeader title="Project Contexts"
+            <CardHeader title={RECIPE_STRINGS.projectContextsTitle}
+                subheader={RECIPE_STRINGS.projectContextsSubtext}
                 action={
                     <Toolbar disableGutters={true} sx={{ gap: 1 }} >
                         <Button

--- a/src/pages/grants/GrantInfoEditor.tsx
+++ b/src/pages/grants/GrantInfoEditor.tsx
@@ -21,6 +21,7 @@ import { useContext, useState } from "react";
 import { HelpTopicContext } from '../../components/HelpTopicContext';
 import type { GrantRecipe } from "../../types";
 import { StableCursorTextField } from '../../components/StableCursorTextfield';
+import { RECIPE_STRINGS } from '../../constants/grantRecipe';
 
 const TagButton = ({ onChange }: { onChange: (newValue: string | null) => void }) => {
   const [edit, setEdit] = useState<boolean>(false);
@@ -110,7 +111,7 @@ export const GrantInfoEditor = ({
         <Grid container spacing={2} alignItems="center">
           <Grid size={2}>
             <Typography>
-              Description <Typography component="span" color="error">*</Typography>
+              {RECIPE_STRINGS.recipeTitle} <Typography component="span" color="error">*</Typography>
             </Typography>
           </Grid>
           <Grid size={10}>

--- a/src/pages/grants/GrantOutputEditor.tsx
+++ b/src/pages/grants/GrantOutputEditor.tsx
@@ -15,6 +15,7 @@ import { useContext, useEffect, useState } from "react";
 import { HelpTopicContext } from '../../components/HelpTopicContext';
 import { StableCursorTextField } from '../../components/StableCursorTextfield';
 import type { GrantOutput } from "../../types";
+import { RECIPE_STRINGS } from '../../constants/grantRecipe';
 
 export const GrantOutputEditor = ({
   fields,
@@ -62,8 +63,9 @@ export const GrantOutputEditor = ({
   return (
     <Card>
       <CardHeader title={<>
-        Output Fields: (field / max symbol count) <span style={{ color: '#d32f2f' }}>*</span>
+        {RECIPE_STRINGS.outputFieldsTitle} <span style={{ color: '#d32f2f' }}>*</span>
       </>}
+        subheader={RECIPE_STRINGS.outputFieldsSubtext}
         slotProps={{ title: { fontWeight: 600, fontSize: 16 } }}
         avatar={<IconButton
           onClick={() => { setHelpTopic('Outputs'); setShowHelp(true) }}

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -29,6 +29,7 @@ import { GrantAiService } from "./grantAiService";
 import { GrantContextEditor } from "./GrantContextEditor";
 import { GrantInfoEditor } from "./GrantInfoEditor";
 import { GrantOutputEditor } from "./GrantOutputEditor";
+import { RECIPE_STRINGS } from '../../constants/grantRecipe';
 
 const HELP_DRAWER_WIDTH = 300;
 const HELP_TITLE = "Our Wave";
@@ -47,7 +48,9 @@ export const TextEditor = ({
   required = false,
   error = false,
   helperText,
-  onBlur
+  onBlur,
+  subheader,
+  helpTopic,
 }: {
   title: string,
   value: string,
@@ -55,7 +58,9 @@ export const TextEditor = ({
   required?: boolean,
   error?: boolean,
   helperText?: string,
-  onBlur?: () => void
+  onBlur?: () => void,
+  subheader?: string,
+  helpTopic?: string,
 }) => {
   const { setHelpTopic } = useContext(HelpTopicContext);
   const { setShowHelp } = useHelp();
@@ -64,9 +69,10 @@ export const TextEditor = ({
       <CardHeader title={<>
         {title} {required && <span style={{ color: '#d32f2f' }}>*</span>}
       </>}
+        subheader={subheader}
         slotProps={{ title: { fontWeight: 600, fontSize: 16 } }}
         avatar={<IconButton
-          onClick={() => { setHelpTopic(title); setShowHelp(true) }}
+          onClick={() => { setHelpTopic(helpTopic ?? title); setShowHelp(true) }}
           color="primary"><InfoCircleOutlined /></IconButton>} />
       <CardContent>
         <StableCursorTextField fullWidth={true}
@@ -88,7 +94,7 @@ export const TextEditor = ({
   )
 }
 
-export const PlainTextCard = ({ title, value }: { title: string, value: string }) => {
+export const PlainTextCard = ({ title, value, helpTopic }: { title: string, value: string, helpTopic?: string }) => {
   const { setHelpTopic } = useContext(HelpTopicContext);
   const { setShowHelp } = useHelp();
   return (
@@ -96,7 +102,7 @@ export const PlainTextCard = ({ title, value }: { title: string, value: string }
       <CardHeader title={title}
         slotProps={{ title: { fontWeight: 600, fontSize: 16 } }}
         avatar={<IconButton
-          onClick={() => { setHelpTopic(title); setShowHelp(true) }}
+          onClick={() => { setHelpTopic(helpTopic ?? title); setShowHelp(true) }}
           color="primary"><InfoCircleOutlined /></IconButton>} />
       <CardContent>
         <Typography>{value}</Typography>
@@ -398,7 +404,8 @@ const GrantRecipesDetailPage: React.FC = () => {
                         onDescriptionBlur={() => setDescriptionTouched(true)}
                       />
                       <TextEditor
-                        title="Template"
+                        title={RECIPE_STRINGS.templateTitle}
+                        helpTopic="Template"
                         value={recipe.template}
                         onChange={handleTemplateChange}
                         required
@@ -413,7 +420,7 @@ const GrantRecipesDetailPage: React.FC = () => {
                         touchedFields={outputFieldTouched}
                         onFieldBlur={handleOutputFieldBlur}
                       />
-                      <PlainTextCard title="Prompt" value={recipe.prompt} />
+                      <PlainTextCard title={RECIPE_STRINGS.promptTitle} helpTopic="Prompt" value={recipe.prompt} />
                     </Stack>
                   </CardContent>
                   <CardActions


### PR DESCRIPTION
## Description

- Add RECIPE_STRINGS constants to src/constants/grantRecipe.ts
- Rename "Description" label to "Recipe Title" in GrantInfoEditor
- Rename "Template" to "What would you like the grant writer to create?"
- Rename "Output Fields: (field / max symbol count)" to "Output Fields"
- Rename "Prompt" to "Prompt (system-generated)"
- Add descriptive subtext to Project Contexts and Output Fields sections

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
