### PR TITLE
Wave-145 - add sortable read-only Rating column to Recipe and Proposal list views

### DIFF
--- a/src/pages/grants/GrantProposalsListPage.tsx
+++ b/src/pages/grants/GrantProposalsListPage.tsx
@@ -2,7 +2,7 @@ import { DeleteOutlined, HomeOutlined } from "@ant-design/icons";
 import { LoadingContext, useNotifications } from "@digitalaidseattle/core";
 import {
   Box, Breadcrumbs, Button, Card, CardContent, CardHeader,
-  IconButton, Toolbar, Tooltip, Typography
+  IconButton, Rating, Toolbar, Tooltip, Typography
 } from "@mui/material";
 import {
   DataGrid,
@@ -108,6 +108,16 @@ const GrantProposalsListPage: React.FC = () => {
       field: "name",
       headerName: "Name",
       width: 200,
+    },
+    {
+      field: "rating",
+      headerName: "Rating",
+      width: 150,
+      type: "number",
+      valueGetter: (_value, row) => row.rating ?? 0,
+      renderCell: (params) => (
+        <Rating value={params.value} readOnly size="small" />
+      ),
     },
     {
       field: "preview",

--- a/src/pages/grants/GrantRecipesListPage.tsx
+++ b/src/pages/grants/GrantRecipesListPage.tsx
@@ -1,5 +1,5 @@
 import { CopyOutlined, DeleteOutlined, HomeOutlined, PlusCircleOutlined } from "@ant-design/icons";
-import { Box, Breadcrumbs, Button, Card, CardContent, CardHeader, Chip, IconButton, Toolbar, Tooltip, Typography } from "@mui/material";
+import { Box, Breadcrumbs, Button, Card, CardContent, CardHeader, Chip, IconButton, Rating, Toolbar, Tooltip, Typography } from "@mui/material";
 import { DataGrid, GridColDef, GridRowParams, GridRowSelectionModel, gridPaginatedVisibleSortedGridRowIdsSelector, useGridApiRef } from "@mui/x-data-grid";
 import { useContext, useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
@@ -116,6 +116,16 @@ const GrantRecipesListPage: React.FC = () => {
       field: "description",
       headerName: "Description",
       width: 400,
+    },
+    {
+      field: "rating",
+      headerName: "Rating",
+      width: 150,
+      type: "number",
+      valueGetter: (_value, row) => row.rating ?? 0,
+      renderCell: (params) => (
+        <Rating value={params.value} readOnly size="small" />
+      ),
     },
     {
       field: "tokenCount",


### PR DESCRIPTION
## Add sortable read-only Rating column to Recipe and Proposal list views

- Add Rating column after Description in GrantRecipesListPage
- Add Rating column after Name in GrantProposalsListPage
- Sortable via MUI DataGrid numeric sort
- Renders read-only stars; null/undefined displays as empty stars

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
