### PR TITLE
Fix local file upload dialog

### DIFF
--- a/src/components/FileUploadDialog.tsx
+++ b/src/components/FileUploadDialog.tsx
@@ -1,33 +1,33 @@
 /**
- *  GoogleDriveFileSearchDialog.ts
+ *  FileUploadDialog.tsx
  *
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import { Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Divider, List, ListItem, ListItemButton, ListItemText, Typography } from "@mui/material";
+import { Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, List, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
 
 import Dropzone from "react-dropzone";
-import { storageService } from "../App";
-import { StorageFile } from "../services/OurWaveStorageService";
-const DEFAULT_FOLDER = import.meta.env.VITE_FIREBASE_STORAGE_FOLDER;
-
 
 
 interface FileUploadDialogProps {
     title?: string;
     open: boolean
-    folderPath?: string;
-    onChange: (files: (File | StorageFile)[] | null) => void
+    onChange: (files: File[] | null) => void
 };
 
-const FileUploadDialog = ({ title = "Select or upload files", open, folderPath = DEFAULT_FOLDER, onChange }: FileUploadDialogProps) => {
+const FileUploadDialog = ({ title = "Select files", open, onChange }: FileUploadDialogProps) => {
 
-    const [files, setFiles] = useState<(File | StorageFile)[]>([]);
-    const [folderFiles, setFolderFiles] = useState<StorageFile[]>([]);
+    const [files, setFiles] = useState<File[]>([]);
 
     function handleConfirm(): void {
         onChange(files);
+        setFiles([]);
+    }
+
+    function handleCancel(): void {
+        onChange(null);
+        setFiles([]);
     }
 
     function handleDeleteFile(idx: number): void {
@@ -37,61 +37,18 @@ const FileUploadDialog = ({ title = "Select or upload files", open, folderPath =
     }
 
     useEffect(() => {
-        if (!open || !folderPath) {
-            return;
+        if (!open) {
+            setFiles([]);
         }
-
-        storageService.list(folderPath)
-            .then(found => setFolderFiles(found as StorageFile[]))
-            .catch(err => {
-                console.error(err);
-                setFolderFiles([]);
-            });
-    }, [open, folderPath]);
-
-    function handleFileList(file: StorageFile): void {
-        setFiles(prev => [...prev, file]);
-    }
+    }, [open]);
 
     return <Dialog
         fullWidth={true}
         open={open}
-        onClose={() => onChange(null)}
+        onClose={handleCancel}
         sx={{ minHeight: '600px' }}>
         <DialogTitle sx={{ fontSize: 16, fontWeight: 600 }}>{title}</DialogTitle>
         <DialogContent>
-            {folderPath && <Box
-                sx={{
-                    flex: 1,
-                    overflowY: "auto",
-                    mb: 2
-                }}>
-                <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                    Select files in server folder: {folderPath}
-                </Typography>
-                <List
-                    sx={{
-                        width: '100%',
-                        bgcolor: 'background.paper',
-                        maxHeight: 200,
-                        overflow: 'auto',
-                        border: 1,
-                        borderColor: "divider",
-                        borderRadius: 1,
-                        p: 0
-                    }}>
-                    {folderFiles.length === 0 && <ListItem><ListItemText primary="No files found." /></ListItem>}
-                    {folderFiles.map(sFile =>
-                        <ListItemButton
-                            key={sFile.fullPath}
-                            sx={{ px: 2, py: 1 }}
-                            onClick={() => handleFileList(sFile)}
-                        >
-                            <ListItemText primary={sFile.name} />
-                        </ListItemButton>)}
-                </List>
-            </Box>}
-            {folderPath && <Divider sx={{ mb: 2 }} />}
             <Dropzone onDrop={acceptedFiles => setFiles([...files, ...acceptedFiles])}>
                 {({ getRootProps, getInputProps }) => (
                     <section>
@@ -125,7 +82,7 @@ const FileUploadDialog = ({ title = "Select or upload files", open, folderPath =
         <DialogActions>
             <Button
                 variant='outlined'
-                onClick={() => onChange(null)}>Cancel</Button>
+                onClick={handleCancel}>Cancel</Button>
             <Button
                 variant='outlined'
                 onClick={handleConfirm}>OK</Button>

--- a/src/pages/grants/GrantContextEditor.tsx
+++ b/src/pages/grants/GrantContextEditor.tsx
@@ -14,7 +14,6 @@ import { FileUploadDialog } from '../../components/FileUploadDialog';
 import { GrantRecipeContext } from '../../components/GrantRecipeContext';
 import { HelpTopicContext } from '../../components/HelpTopicContext';
 import { StableCursorTextField } from '../../components/StableCursorTextfield';
-import { StorageFile } from '../../services/OurWaveStorageService';
 import { GrantContext, GrantRecipe } from '../../types';
 import { GrantAiService } from './grantAiService';
 
@@ -115,27 +114,37 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
         onChange({ ...recipe, contexts: revised });
     }
 
-    async function handleFileSelection(files: (File | StorageFile)[] | null) {
-        if (files) {
-            const contexts = files
-                .filter(file => {
-                    const fileType = file.type;
-                    if (!fileType || !SUPPORTED_FILE_TYPES.includes(fileType)) {
-                        notifications.error(`Unsupported file type: ${file.type}. Supported types are: ${SUPPORTED_FILE_TYPES.join(", ")}`);
-                        return false;
-                    } else {
-                        return true;
-                    }
-                })
-                .map(async file => {
-                    const tokenCount = file instanceof File
-                        ? await grantAiService.calcFileTokenCount(recipe.modelType, file)
-                        : await grantAiService.calcStorageFileTokenCount(recipe.modelType, file);
-                    return ({ type: file.type!, value: "", name: file.name, tokenCount: tokenCount, file: file });
-                })
-            addContexts(await Promise.all(contexts));
-        }
+    async function handleFileSelection(files: File[] | null) {
         setShowUploadDialog(false);
+
+        if (!files) {
+            return;
+        }
+
+        const supportedFiles = files.filter(file => {
+            const fileType = file.type;
+            if (!fileType || !SUPPORTED_FILE_TYPES.includes(fileType)) {
+                notifications.error(`Unsupported file type: ${file.name}. Supported types are: ${SUPPORTED_FILE_TYPES.join(", ")}`);
+                return false;
+            }
+            return true;
+        });
+
+        const newContexts = await Promise.all(supportedFiles.map(async file => {
+            let tokenCount = 0;
+            try {
+                tokenCount = await grantAiService.calcFileTokenCount(recipe.modelType, file);
+            } catch (err) {
+                console.error("Error calculating token count for file", err);
+                notifications.error(`Could not calculate token count for ${file.name}. The file was added with 0 tokens.`);
+            }
+
+            return ({ type: file.type, value: "", name: file.name, tokenCount: tokenCount, file: file });
+        }));
+
+        if (newContexts.length > 0) {
+            addContexts(newContexts);
+        }
     }
 
     return (


### PR DESCRIPTION
## Description

This fixes the broken file upload flow in Project Contexts.

  The file picker was still showing the old server folder option, so I removed that and kept the
  flow focused on choosing files from your computer. I also fixed the OK button behavior so the
  dialog closes after confirming, and the selected files get added even if token counting has a
  problem.

  ## What type of PR is this? (check all applicable)

  - [ ] Refactor
  - [ ] Feature
  - [x] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  ## Related Tickets & Documents

https://digital-aid-seattle.atlassian.net/browse/WAVE-157

  ## QA Instructions, Screenshots, Recordings

  1. Open a grant recipe and go to the Project Contexts section.
  2. Click the `File` button.
  3. Confirm the dialog no longer shows a `Server Folder` or server-folder file list.
  4. Select multiple local files from your computer
  5. Click `OK`.
  6. Confirm the dialog closes.
  7. Confirm supported files are added to the Project Contexts list.
  8. Try selecting an unsupported file type and confirm an error notification is shown.