### PR TITLE
WAVE 163 - Feature/loading indicator

### DIFF
--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -32,6 +32,7 @@ export const RECIPE_DETAIL_LABELS = {
     outputFieldsTitle: "Output Fields",
     outputFieldsSubtext: "Add the questions or sections from the grant application that you want the grant writer to answer.",
     promptTitle: "Prompt (system-generated)",
+    tokenCountUnavailable: "count unavailable",
 };
 
 export const PROPOSAL_LABELS = {

--- a/src/pages/grants/GrantContextEditor.tsx
+++ b/src/pages/grants/GrantContextEditor.tsx
@@ -4,8 +4,8 @@
  *  @copyright 2025 Digital Aid Seattle
  *
  */
-import { DeleteOutlined, InfoCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import { Button, Card, CardContent, CardHeader, FormControl, IconButton, Stack, Toolbar, Typography } from "@mui/material";
+import { CheckCircleOutlined, DeleteOutlined, InfoCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { Button, Card, CardContent, CardHeader, CircularProgress, FormControl, IconButton, Stack, Toolbar, Tooltip, Typography } from "@mui/material";
 import React, { useContext, useEffect, useState } from 'react';
 
 import { useHelp, useNotifications } from '@digitalaidseattle/core';
@@ -23,15 +23,17 @@ const SUPPORTED_FILE_TYPES = [
     "application/pdf",
     "text/html",
     "application/json",
-    "text/markdown"];
+    "text/markdown"
+];
 
 interface ContextRowProps {
     index: number;
     context: GrantContext;
     onChange: (index: number, param: GrantContext) => void
     onDelete: (index: number) => void
+    isDone?: boolean;
 };
-const ContextRow = ({ index, context, onChange, onDelete }: ContextRowProps) => {
+const ContextRow = ({ index, context, onChange, onDelete, isDone }: ContextRowProps) => {
 
     function handleTextChange(e: React.ChangeEvent<HTMLInputElement>): void {
         onChange(index, { ...context, value: e.target.value });
@@ -65,13 +67,20 @@ const ContextRow = ({ index, context, onChange, onDelete }: ContextRowProps) => 
                 />}
             {(SUPPORTED_FILE_TYPES.includes(context.type)) &&
                 <>
-                    <FormControl fullWidth={true} sx={{ border: '1px solid', borderBlockColor: 'grey', padding: 2, borderRadius: 1, pr: 1 }}>
-                        <Typography >File: {context.name}</Typography>
+                    <FormControl fullWidth={true} sx={{ border: '1px solid', borderBlockColor: isDone ? 'success.main' : 'grey', padding: 2, borderRadius: 1, pr: 1, display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 1 }}>
+                        <Typography>File: {context.name}</Typography>
+                        {isDone && (
+                            <Tooltip title="Upload complete">
+                                <CheckCircleOutlined style={{ color: '#2e7d32', marginLeft: 8, fontSize: 18 }} />
+                            </Tooltip>
+                        )}
                     </FormControl>
                 </>
             }
             <Typography variant="body2" sx={{ alignSelf: 'center', minWidth: 80 }}>
-                Tokens: {context.tokenCount}
+                {context.tokenCountUnavailable
+                    ? 'Token count = count unavailable'
+                    : `Tokens: ${context.tokenCount}`}
             </Typography>
         </Stack >
     )
@@ -79,9 +88,10 @@ const ContextRow = ({ index, context, onChange, onDelete }: ContextRowProps) => 
 
 type GrantContextEditorProps = {
     onChange: (recipe: GrantRecipe) => void;
+    onUploadingChange?: (isUploading: boolean) => void;
 };
 
-export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange }) => {
+export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange, onUploadingChange }) => {
     const grantAiService = GrantAiService.getInstance();
     const notifications = useNotifications();
 
@@ -89,6 +99,8 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
     const { setShowHelp } = useHelp();
     const { recipe } = useContext(GrantRecipeContext);
     const [contexts, setContexts] = React.useState<GrantContext[]>([]);
+    const [uploadingFileNames, setUploadingFileNames] = useState<Set<string>>(new Set());
+    const [doneFileNames, setDoneFileNames] = useState<Set<string>>(new Set());
 
     const [showUploadDialog, setShowUploadDialog] = useState<boolean>(false);
     useEffect(() => {
@@ -127,21 +139,33 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
             return true;
         });
 
-        const newContexts = await Promise.all(supportedFiles.map(async file => {
-            let tokenCount = 0;
-            try {
-                tokenCount = await grantAiService.calcFileTokenCount(recipe.modelType, file);
-            } catch (err) {
-                console.error("Error calculating token count for file", err);
-                notifications.error(`Could not calculate token count for ${file.name}. The file was added with 0 tokens.`);
-            }
+        if (supportedFiles.length === 0) return;
 
-            return ({ type: file.type, value: "", name: file.name, tokenCount: tokenCount, file: file });
+        // Show spinner rows immediately via local state — no parent state change needed yet
+        const uploadingNames = new Set(supportedFiles.map(f => f.name));
+        setUploadingFileNames(uploadingNames);
+        onUploadingChange?.(true);
+
+        // Calculate token counts; null means unavailable (e.g. browser CORS restriction on Gemini Files API)
+        const newContexts = await Promise.all(supportedFiles.map(async file => {
+            const tokenCount = await grantAiService.calcFileTokenCount(recipe.modelType, file);
+            return ({
+                type: file.type,
+                value: "",
+                name: file.name,
+                tokenCount: tokenCount ?? 0,
+                tokenCountUnavailable: tokenCount === null,
+                file: file
+            } as GrantContext);
         }));
 
-        if (newContexts.length > 0) {
-            addContexts(newContexts);
-        }
+        // Add completed contexts, clear spinners, show done checkmarks for 2s
+        onChange({ ...recipe, contexts: [...(contexts ?? []), ...newContexts] });
+        setUploadingFileNames(new Set());
+        onUploadingChange?.(false);
+        const completedNames = new Set(newContexts.map(c => c.name as string));
+        setDoneFileNames(completedNames);
+        setTimeout(() => setDoneFileNames(new Set()), 2000);
     }
 
     return (
@@ -178,7 +202,25 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
                             index={idx}
                             context={context}
                             onChange={udpateContext}
-                            onDelete={removeContext} />
+                            onDelete={removeContext}
+                            isDone={!!context.name && doneFileNames.has(context.name)} />
+                    ))}
+                    {Array.from(uploadingFileNames).map(name => (
+                        <Stack
+                            direction="row"
+                            key={`uploading-${name}`}
+                            gap={1}
+                            sx={{ position: 'relative', width: '100%' }}
+                        >
+                            <Button color="error" disabled><DeleteOutlined /></Button>
+                            <FormControl fullWidth sx={{ border: '1px solid', borderBlockColor: 'grey', padding: 2, borderRadius: 1, display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 1 }}>
+                                <Typography>File: {name}</Typography>
+                                <CircularProgress size={20} sx={{ ml: 1 }} />
+                            </FormControl>
+                            <Typography variant="body2" sx={{ alignSelf: 'center', minWidth: 80 }}>
+                                Processing...
+                            </Typography>
+                        </Stack>
                     ))}
                 </Stack>
                 <FileUploadDialog

--- a/src/pages/grants/GrantContextEditor.tsx
+++ b/src/pages/grants/GrantContextEditor.tsx
@@ -119,8 +119,16 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
     }
 
     function removeContext(index: number) {
+        const removed = contexts[index];
         const revised = contexts.filter((_, i) => i !== index);
         onChange({ ...recipe, contexts: revised });
+        if (removed?.name) {
+            setDoneFileNames(prev => {
+                const next = new Set(prev);
+                next.delete(removed.name as string);
+                return next;
+            });
+        }
     }
 
     async function handleFileSelection(files: File[] | null) {
@@ -147,8 +155,22 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
         onUploadingChange?.(true);
 
         // Calculate token counts; null means unavailable (e.g. browser CORS restriction on Gemini Files API)
+        // Text-readable files are read directly and counted via calcTokenCount (works in browser).
+        // Binary files (e.g. PDF) must use calcFileTokenCount which requires server-side API — returns null in browser.
+        const TEXT_READABLE_TYPES = ["text/plain", "text/html", "application/json", "text/markdown"];
         const newContexts = await Promise.all(supportedFiles.map(async file => {
-            const tokenCount = await grantAiService.calcFileTokenCount(recipe.modelType, file);
+            let tokenCount: number | null = null;
+            if (TEXT_READABLE_TYPES.includes(file.type)) {
+                try {
+                    const text = await file.text();
+                    tokenCount = await geminiService.calcTokenCount(recipe.modelType, text);
+                } catch (err) {
+                    console.error("Error calculating token count for text file", err);
+                    tokenCount = null;
+                }
+            } else {
+                tokenCount = await grantAiService.calcFileTokenCount(recipe.modelType, file);
+            }
             return ({
                 type: file.type,
                 value: "",
@@ -164,8 +186,7 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
         setUploadingFileNames(new Set());
         onUploadingChange?.(false);
         const completedNames = new Set(newContexts.map(c => c.name as string));
-        setDoneFileNames(completedNames);
-        setTimeout(() => setDoneFileNames(new Set()), 2000);
+        setDoneFileNames(prev => new Set([...prev, ...completedNames]));
     }
 
     return (

--- a/src/pages/grants/GrantContextEditor.tsx
+++ b/src/pages/grants/GrantContextEditor.tsx
@@ -5,7 +5,7 @@
  *
  */
 import { CheckCircleOutlined, DeleteOutlined, InfoCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import { Button, Card, CardContent, CardHeader, CircularProgress, FormControl, IconButton, Stack, Toolbar, Tooltip, Typography } from "@mui/material";
+import { Box, Button, Card, CardContent, CardHeader, CircularProgress, FormControl, IconButton, Stack, Toolbar, Tooltip, Typography } from "@mui/material";
 import React, { useContext, useEffect, useState } from 'react';
 
 import { useHelp, useNotifications } from '@digitalaidseattle/core';
@@ -71,16 +71,16 @@ const ContextRow = ({ index, context, onChange, onDelete, isDone }: ContextRowPr
                         <Typography>File: {context.name}</Typography>
                         {isDone && (
                             <Tooltip title="Upload complete">
-                                <CheckCircleOutlined style={{ color: '#2e7d32', marginLeft: 8, fontSize: 18 }} />
+                                <Box component={CheckCircleOutlined} sx={{ color: 'success.main', ml: 1, fontSize: 18 }} />
                             </Tooltip>
                         )}
                     </FormControl>
                 </>
             }
             <Typography variant="body2" sx={{ alignSelf: 'center', minWidth: 80 }}>
-                {context.tokenCountUnavailable
-                    ? 'Token count = count unavailable'
-                    : `Tokens: ${context.tokenCount}`}
+                {context.tokenCount !== undefined
+                    ? `Tokens: ${context.tokenCount}`
+                    : `Tokens: ${RECIPE_STRINGS.tokenCountUnavailable}`}
             </Typography>
         </Stack >
     )
@@ -175,8 +175,7 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
                 type: file.type,
                 value: "",
                 name: file.name,
-                tokenCount: tokenCount ?? 0,
-                tokenCountUnavailable: tokenCount === null,
+                tokenCount: tokenCount ?? undefined,
                 file: file
             } as GrantContext);
         }));

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -131,13 +131,14 @@ const GrantRecipesDetailPage: React.FC = () => {
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [rating, setRating] = useState<number>(0);
+  const [isFileUploading, setIsFileUploading] = useState<boolean>(false);
 
   const isDescriptionMissing = !hasValidDescription;
   const isOutputFieldsIncomplete = !hasCompleteOutputFields;
   const isTemplateMissing = !hasValidTemplate;
   const isSaveDisabled = loading || !dirty || isDescriptionMissing;
   const isCloneDisabled = loading || isDescriptionMissing;
-  const isGenerateDisabled = loading || isDescriptionMissing || isOutputFieldsIncomplete || isTemplateMissing;
+  const isGenerateDisabled = loading || isFileUploading || isDescriptionMissing || isOutputFieldsIncomplete || isTemplateMissing;
 
   const actionMessages: string[] = [];
   if (!loading && hasValidDescription && !dirty) {
@@ -425,7 +426,7 @@ const GrantRecipesDetailPage: React.FC = () => {
                         helperText={templateTouched && isTemplateMissing ? "Template is required to generate." : " "}
                         onBlur={() => setTemplateTouched(true)}
                       />
-                      <GrantContextEditor onChange={handleGrantContextsChange} />
+                      <GrantContextEditor onChange={handleGrantContextsChange} onUploadingChange={setIsFileUploading} />
                       <GrantOutputEditor
                         fields={recipe.outputsWithWordCount}
                         onChange={handleGrantOutputChange}

--- a/src/pages/grants/grantAiService.ts
+++ b/src/pages/grants/grantAiService.ts
@@ -124,29 +124,31 @@ class GrantAiService {
             .then(response => response.totalTokens ?? 0);
     }
 
-    async calcFileTokenCount(model: string, file: File): Promise<number> {
-        const ai = this.requireAi();
-        // const bytes = await fileToBase64(file);
-        console.log("Calculating token count for file:", file);
-        const uploaded = await ai.files.upload({
-            file: file,
-            config: { mimeType: file.type },
-        });
-
-        return ai.models
-            .countTokens(
-                {
-                    model: model,
-                    contents: createUserContent([
-                        "Count tokens for this document",
-                        createPartFromUri(uploaded.uri!, uploaded.mimeType!),
-                    ])
-                })
-            .then(response => response.totalTokens ?? 0)
-            .catch(err => {
-                console.error("Error calculating token count for file", err);
-                return 0;
-            })
+    async calcFileTokenCount(model: string, file: File): Promise<number | null> {
+        try {
+            const ai = this.requireAi();
+            console.log("Calculating token count for file:", file);
+            const uploaded = await ai.files.upload({
+                file: file,
+                config: { mimeType: file.type },
+            });
+            const response = await ai.models.countTokens({
+                model: model,
+                contents: createUserContent([
+                    "Count tokens for this document",
+                    createPartFromUri(uploaded.uri!, uploaded.mimeType!),
+                ])
+            });
+            return response.totalTokens ?? 0;
+        } catch (err) {
+            // NOTE: ai.files.upload() is a server-side Gemini Files API — it fails in the
+            // browser due to CORS and API key restrictions. Token count will be unavailable
+            // for binary files (e.g. PDFs) uploaded directly from the browser.
+            // calcStorageFileTokenCount has the same issue and also returns null-equivalent.
+            // TODO: Move file token counting to a Firebase Cloud Function.
+            console.error("Error calculating token count for file", err);
+            return null;
+        }
     }
 
     async calcStorageFileTokenCount(model: string, file: StorageFile): Promise<number> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,7 @@ export type GrantContext = {
   type: string;
   name: string | null;
   value: string | null;
-  tokenCount: number;
-  tokenCountUnavailable?: boolean;
+  tokenCount?: number;
   file?: File;
   fileUrl?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type GrantContext = {
   name: string | null;
   value: string | null;
   tokenCount: number;
+  tokenCountUnavailable?: boolean;
   file?: File;
   fileUrl?: string;
 }


### PR DESCRIPTION
## Description

Currently, when a user uploads files, there is no visual feedback indicating that the upload is in progress. This creates confusion, as it appears that nothing is happening after file selection.

Add a loading indicator to communicate that:
- The files have been successfully received
- The upload is currently in progress

The solution should provide clear feedback without disrupting the user experience (e.g., do not block or blur the entire screen).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## QA Instructions, Screenshots, Recordings

- Upload a .txt or .md file  → spinner appears → checkmark + real token count shown
- Upload a .pdf file → spinner appears → checkmark + "Token count = count unavailable" shown
- If file not supported then got error : Unsupported file type: Our Wave_ Product Requirements Document(PRD).docx. Supported types are: text/plain, application/pdf, text/html, application/json, text/markdown

<img width="1194" height="283" alt="image" src="https://github.com/user-attachments/assets/8b289033-3b7c-4072-a8f7-45a5d450313b" />
