### PR TITLE
WAVE-159: Remove proposalIds field 

### DIFF
--- a/src/pages/grants/GrantProposalsDetailPage.tsx
+++ b/src/pages/grants/GrantProposalsDetailPage.tsx
@@ -223,7 +223,7 @@ const GrantProposalsDetailPage: React.FC = () => {
       setLoading(true);
       setIsDeleting(true);
 
-      await deleteProposal(proposal, recipe);
+      await deleteProposal(proposal);
 
       notifications.success(LABELS.DELETE_SUCCESS);
       setOpenDeleteDialog(false);

--- a/src/pages/grants/GrantProposalsDetailPage.tsx
+++ b/src/pages/grants/GrantProposalsDetailPage.tsx
@@ -34,7 +34,7 @@ import { TextEdit } from "../../components/TextEdit";
 import { SUPPORTED_DOWNLOAD_TYPE } from "../../services/ProposalExporter";
 import { grantProposalService } from "../../services/grantProposalService";
 import { grantRecipeService } from "../../services/grantRecipeService";
-import { deleteProposal } from "../../transactions/DeleteProposal";
+
 import type { GrantOutput, GrantProposal, GrantRecipe } from "../../types";
 import { DateUtils } from "../../utils/dateUtils";
 
@@ -223,7 +223,7 @@ const GrantProposalsDetailPage: React.FC = () => {
       setLoading(true);
       setIsDeleting(true);
 
-      await deleteProposal(proposal);
+      await grantProposalService.deleteProposal(proposal);
 
       notifications.success(LABELS.DELETE_SUCCESS);
       setOpenDeleteDialog(false);

--- a/src/pages/grants/GrantProposalsListPage.tsx
+++ b/src/pages/grants/GrantProposalsListPage.tsx
@@ -16,7 +16,7 @@ import { useContext, useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { LoadingOverlay } from "../../components/LoadingOverlay";
 import { grantProposalService } from "../../services/grantProposalService";
-import { deleteProposal } from "../../transactions/DeleteProposal";
+
 import type { GrantProposal, Timestamp } from "../../types";
 import { DateUtils } from "../../utils/dateUtils";
 import { PROPOSAL_LABELS } from "../../constants/labels";
@@ -68,7 +68,7 @@ const GrantProposalsListPage: React.FC = () => {
     });
 
     Promise
-      .all(selectedProposals.map((proposal) => deleteProposal(proposal)))
+      .all(selectedProposals.map((proposal) => grantProposalService.deleteProposal(proposal)))
       .then(() => {
         fetchProposals();
         notifications.success(LABELS.DELETE_SUCCESS);

--- a/src/services/grantProposalService.ts
+++ b/src/services/grantProposalService.ts
@@ -89,6 +89,13 @@ class GrantProposalService extends FirestoreService<GrantProposal> {
     return this.proposalExporter.run(proposal, downloadType);
   }
 
+  async deleteProposal(proposal: Pick<GrantProposal, "id" | "grantRecipeId">): Promise<void> {
+    if (!proposal.id) {
+      throw new Error("Proposal ID is required");
+    }
+    await this.delete(String(proposal.id));
+  }
+
 }
 
 

--- a/src/services/grantRecipeService.ts
+++ b/src/services/grantRecipeService.ts
@@ -33,7 +33,6 @@ class GrantRecipeService extends FirestoreService<GrantRecipe> {
       outputsWithWordCount: [{ name: '', maxWords: 500, unit: 'words' }],
       inputParameters: [],
       tokenCount: 0,
-      proposalIds: [],
       modelType: "gemini-2.5-flash",
     };
   }

--- a/src/services/validation/schemas.ts
+++ b/src/services/validation/schemas.ts
@@ -28,7 +28,6 @@ export const grantRecipeSchema = z.object({
 
   inputParameters: z.array(grantInput).optional(),
   outputsWithWordCount: z.array(grantOutput).optional(),
-  proposalIds: z.array(z.string().trim()).optional(),
 });
 
 // Proposal rules

--- a/src/transactions/DeleteProposal.test.ts
+++ b/src/transactions/DeleteProposal.test.ts
@@ -1,22 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { GrantProposal, GrantRecipe } from "../types";
+import type { GrantProposal } from "../types";
 
 const mocks = vi.hoisted(() => ({
   deleteMock: vi.fn(),
-  getByIdMock: vi.fn(),
-  updateMock: vi.fn(),
 }));
 
 vi.mock("../services/grantProposalService", () => ({
   grantProposalService: {
     delete: mocks.deleteMock,
-  },
-}));
-
-vi.mock("../services/grantRecipeService", () => ({
-  grantRecipeService: {
-    getById: mocks.getByIdMock,
-    update: mocks.updateMock,
   },
 }));
 
@@ -27,93 +18,19 @@ describe("deleteProposal", () => {
     vi.clearAllMocks();
   });
 
-  it("deletes the proposal and removes its id from the parent recipe", async () => {
-    const recipe: GrantRecipe = {
-      id: "recipe-123",
-      createdAt: new Date(),
-      createdBy: "tester@example.com",
-      updatedAt: new Date(),
-      updatedBy: "tester@example.com",
-      lastSubmitted: null,
-      description: "Recipe",
-      tags: [],
-      rating: 0,
-      template: "",
-      prompt: "",
-      contexts: [],
-      outputsWithWordCount: [],
-      inputParameters: [],
-      tokenCount: 0,
-      proposalIds: ["proposal-1", "proposal-2"],
-      modelType: "gemini-2.5-flash",
-    };
-
+  it("deletes the proposal", async () => {
     mocks.deleteMock.mockResolvedValue(undefined);
-    mocks.updateMock.mockResolvedValue({ ...recipe, proposalIds: ["proposal-2"] });
 
     await deleteProposal(
-      {
-        id: "proposal-1",
-        grantRecipeId: "recipe-123",
-      } as GrantProposal,
-      recipe
+      { id: "proposal-1", grantRecipeId: "recipe-123" } as GrantProposal
     );
 
     expect(mocks.deleteMock).toHaveBeenCalledWith("proposal-1");
-    expect(mocks.getByIdMock).not.toHaveBeenCalled();
-    expect(mocks.updateMock).toHaveBeenCalledWith("recipe-123", {
-      ...recipe,
-      proposalIds: ["proposal-2"],
-    });
   });
 
-  it("fetches the recipe when one is not provided", async () => {
-    const recipe: GrantRecipe = {
-      id: "recipe-123",
-      createdAt: new Date(),
-      createdBy: "tester@example.com",
-      updatedAt: new Date(),
-      updatedBy: "tester@example.com",
-      lastSubmitted: null,
-      description: "Recipe",
-      tags: [],
-      rating: 0,
-      template: "",
-      prompt: "",
-      contexts: [],
-      outputsWithWordCount: [],
-      inputParameters: [],
-      tokenCount: 0,
-      proposalIds: ["proposal-1"],
-      modelType: "gemini-2.5-flash",
-    };
-
-    mocks.deleteMock.mockResolvedValue(undefined);
-    mocks.getByIdMock.mockResolvedValue(recipe);
-    mocks.updateMock.mockResolvedValue({ ...recipe, proposalIds: [] });
-
-    await deleteProposal({
-      id: "proposal-1",
-      grantRecipeId: "recipe-123",
-    } as GrantProposal);
-
-    expect(mocks.getByIdMock).toHaveBeenCalledWith("recipe-123");
-    expect(mocks.updateMock).toHaveBeenCalledWith("recipe-123", {
-      ...recipe,
-      proposalIds: [],
-    });
-  });
-
-  it("skips recipe cleanup when the proposal has no recipe id", async () => {
-    mocks.deleteMock.mockResolvedValue(undefined);
-
-    await deleteProposal({
-      id: "proposal-1",
-      grantRecipeId: "",
-    } as GrantProposal);
-
-    expect(mocks.deleteMock).toHaveBeenCalledWith("proposal-1");
-    expect(mocks.getByIdMock).not.toHaveBeenCalled();
-    expect(mocks.updateMock).not.toHaveBeenCalled();
+  it("throws if proposal has no id", async () => {
+    await expect(
+      deleteProposal({ id: undefined, grantRecipeId: "recipe-123" } as any)
+    ).rejects.toThrow("Proposal ID is required");
   });
 });

--- a/src/transactions/DeleteProposal.ts
+++ b/src/transactions/DeleteProposal.ts
@@ -1,35 +1,14 @@
 import { grantProposalService } from "../services/grantProposalService";
-import { grantRecipeService } from "../services/grantRecipeService";
-import type { GrantProposal, GrantRecipe } from "../types";
+import type { GrantProposal } from "../types";
 
 export async function deleteProposal(
-  proposal: Pick<GrantProposal, "id" | "grantRecipeId">,
-  recipe?: GrantRecipe | null
+  proposal: Pick<GrantProposal, "id" | "grantRecipeId">
 ): Promise<void> {
   if (!proposal.id) {
     throw new Error("Proposal ID is required");
   }
 
   const proposalId = String(proposal.id);
-  const recipeId = proposal.grantRecipeId ? String(proposal.grantRecipeId) : "";
 
   await grantProposalService.delete(proposalId);
-
-  if (recipeId.trim() === "") {
-    return;
-  }
-
-  try {
-    const parentRecipe = recipe ?? await grantRecipeService.getById(recipeId);
-    const nextProposalIds = (parentRecipe.proposalIds ?? []).filter((id) => id !== proposalId);
-
-    if (nextProposalIds.length !== (parentRecipe.proposalIds ?? []).length) {
-      await grantRecipeService.update(parentRecipe.id as string, {
-        ...parentRecipe,
-        proposalIds: nextProposalIds,
-      });
-    }
-  } catch (error) {
-    console.warn("Proposal deleted but recipe reference cleanup failed:", error);
-  }
 }

--- a/src/transactions/GenerateProposal.test.ts
+++ b/src/transactions/GenerateProposal.test.ts
@@ -44,7 +44,6 @@ describe("GenerateProposal", () => {
       ],
       inputParameters: [],
       tokenCount: 0,
-      proposalIds: [],
       modelType: "gemini-2.5-flash",
     };
 
@@ -88,7 +87,6 @@ describe("GenerateProposal", () => {
       outputsWithWordCount: [],
       tokenCount: 0,
       inputParameters: [],
-      proposalIds: [],
       modelType: "gemini-2.5-flash",
     };
 

--- a/src/transactions/GenerateProposal.ts
+++ b/src/transactions/GenerateProposal.ts
@@ -55,7 +55,7 @@ export async function generateProposal(recipe: GrantRecipe): Promise<GrantPropos
 
     const proposal = {
         ...grantProposalService.empty(),
-        name: `${savedRecipe.description} (${savedRecipe.proposalIds.length + 1})`,
+        name: `${savedRecipe.description} (${(savedRecipe.lastSubmitted as Date).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })})`,
         grantRecipeId: String(savedRecipe.id),
         structuredResponse: JSON.parse(response.text!),
         rating: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,6 @@ export type GrantRecipe = Entity & {
   inputParameters: GrantInput[];
   outputsWithWordCount: GrantOutput[];
   tokenCount: number;
-  proposalIds: string[];
   modelType: string; // "gemini-2.5-flash", etc.
 };
 


### PR DESCRIPTION
## Description
Removed the recipe.projectIds field from the application to simplify updates.

- Removed proposalIds from GrantRecipe type, empty(), and Zod schema
- Replaced proposalIds.length-based proposal naming with lastSubmitted timestamp
- Removed proposalIds sync logic from DeleteProposal transaction
- Updated DeleteProposal and GenerateProposal tests to reflect changes

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimisation
- [ ] Documentation Update

## Acceptance criteria

Verify that the projectIds field can be removed (reading references is essential).
Remove the field from the type.
Identify and address any other write references related to projectIds.

