### PR TITLE
WAVE 111: dynamically update estimated token count from project contexts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@digitalaidseattle/mui": "^1.0.34",
         "@google/genai": "^1.38.0",
         "@mui/x-data-grid": "^8.16.0",
-        "docx": "^9.6.1",
+        "docx": "^9.7.1",
         "file-saver": "^2.0.5",
         "handlebars": "^4.7.8",
         "jspdf": "^4.2.1",
@@ -4629,9 +4629,9 @@
       }
     },
     "node_modules/docx": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
-      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
+      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@digitalaidseattle/mui": "^1.0.34",
     "@google/genai": "^1.38.0",
     "@mui/x-data-grid": "^8.16.0",
-    "docx": "^9.6.1",
+    "docx": "^9.7.1",
     "file-saver": "^2.0.5",
     "handlebars": "^4.7.8",
     "jspdf": "^4.2.1",

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -325,9 +325,11 @@ const GrantRecipesDetailPage: React.FC = () => {
   }
 
   function handleGrantContextsChange(revised: GrantRecipe): void {
-    console.log(revised)
-    // prompt not affected by contexts change
-    setRecipe(revised);
+    const totalTokenCount = (revised.contexts ?? []).reduce(
+      (sum, ctx) => sum + (ctx.tokenCount ?? 0),
+      0
+    );
+    setRecipe({ ...revised, tokenCount: totalTokenCount });
     setDirty(true);
   }
 
@@ -402,7 +404,7 @@ const GrantRecipesDetailPage: React.FC = () => {
                   }}
                 >
                   <CardHeader title={recipe.description ?? ""}
-                    action={`Token count = ${recipe.tokenCount}`}
+                    action={`Estimated Token Count = ${recipe.tokenCount}`}
                     subheader={`Last updated: ${lastUpdated}`} />
                   <CardContent
                     sx={{


### PR DESCRIPTION
## Description
The token count counter displayed in the top-right of the page should dynamically update to reflect all project context inputs, including uploaded or selected files and manually entered text. Due to a change with prompt-field usage, this token count does not get updated.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## QA Instructions, Screenshots, Recordings
Estimated token count - 

<img width="2866" height="488" alt="image" src="https://github.com/user-attachments/assets/5b78936c-9d88-4347-b232-73ce4eac24c4" />


