### PR TITLE
enable recipe save button while editing

### DIFF
--- a/src/components/StableCursorTextfield.tsx
+++ b/src/components/StableCursorTextfield.tsx
@@ -9,8 +9,10 @@ import React, { useEffect, useState } from "react";
 export const StableCursorTextField = ({
     value,
     onChange,
+    onBlur,
+    onEdit,
     ...props
-}: React.ComponentProps<typeof TextField>) => {
+}: React.ComponentProps<typeof TextField> & { onEdit?: () => void }) => {
     const [localValue, setLocalValue] = useState<unknown>('');
 
     useEffect(() => {
@@ -19,10 +21,14 @@ export const StableCursorTextField = ({
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         setLocalValue(e.target.value);
+        onEdit?.();
     };
 
-    const handleBlur = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        onChange!(e);
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        if (localValue !== value) {
+            onChange?.(e as unknown as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);
+        }
+        onBlur?.(e);
     };
 
     return (

--- a/src/pages/grants/GrantContextEditor.tsx
+++ b/src/pages/grants/GrantContextEditor.tsx
@@ -31,9 +31,10 @@ interface ContextRowProps {
     context: GrantContext;
     onChange: (index: number, param: GrantContext) => void
     onDelete: (index: number) => void
+    onEdit?: () => void;
     isDone?: boolean;
-};
-const ContextRow = ({ index, context, onChange, onDelete, isDone }: ContextRowProps) => {
+}
+const ContextRow = ({ index, context, onChange, onDelete, onEdit, isDone }: ContextRowProps) => {
 
     function handleTextChange(e: React.ChangeEvent<HTMLInputElement>): void {
         onChange(index, { ...context, value: e.target.value });
@@ -61,6 +62,7 @@ const ContextRow = ({ index, context, onChange, onDelete, isDone }: ContextRowPr
                     value={context.value}
                     placeholder='Enter context information here'
                     onChange={handleTextChange}
+                    onEdit={onEdit}
                     multiline={true}
                     minRows={1}
                     maxRows={3}
@@ -88,10 +90,11 @@ const ContextRow = ({ index, context, onChange, onDelete, isDone }: ContextRowPr
 
 type GrantContextEditorProps = {
     onChange: (recipe: GrantRecipe) => void;
+    onEdit?: () => void;
     onUploadingChange?: (isUploading: boolean) => void;
 };
 
-export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange, onUploadingChange }) => {
+export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange, onEdit, onUploadingChange }) => {
     const grantAiService = GrantAiService.getInstance();
     const notifications = useNotifications();
 
@@ -113,9 +116,13 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
     }
 
     async function udpateContext(index: number, revised: GrantContext) {
-        revised.tokenCount = await geminiService.calcTokenCount(recipe.modelType, revised.value || '');
-        contexts[index] = revised;
-        onChange({ ...recipe, contexts: contexts.slice() });
+        const revisedContexts = contexts.slice();
+        revisedContexts[index] = revised;
+        onChange({ ...recipe, contexts: revisedContexts });
+
+        const tokenCount = await geminiService.calcTokenCount(recipe.modelType, revised.value || '');
+        revisedContexts[index] = { ...revised, tokenCount };
+        onChange({ ...recipe, contexts: revisedContexts });
     }
 
     function removeContext(index: number) {
@@ -223,6 +230,7 @@ export const GrantContextEditor: React.FC<GrantContextEditorProps> = ({ onChange
                             context={context}
                             onChange={udpateContext}
                             onDelete={removeContext}
+                            onEdit={onEdit}
                             isDone={!!context.name && doneFileNames.has(context.name)} />
                     ))}
                     {Array.from(uploadingFileNames).map(name => (

--- a/src/pages/grants/GrantInfoEditor.tsx
+++ b/src/pages/grants/GrantInfoEditor.tsx
@@ -65,12 +65,14 @@ export const GrantInfoEditor = ({
   recipe,
   onChange,
   showDescriptionError = false,
-  onDescriptionBlur
+  onDescriptionBlur,
+  onEdit
 }: {
   recipe: GrantRecipe,
   onChange: (updated: GrantRecipe) => void,
   showDescriptionError?: boolean,
-  onDescriptionBlur?: () => void
+  onDescriptionBlur?: () => void,
+  onEdit?: () => void
 }) => {
 
   const { setHelpTopic } = useContext(HelpTopicContext);
@@ -119,6 +121,7 @@ export const GrantInfoEditor = ({
               error={showDescriptionError}
               helperText={showDescriptionError ? "Description is required." : " "}
               onBlur={onDescriptionBlur}
+              onEdit={onEdit}
               onChange={(evt) => handleDescriptionChange(evt.target.value)} />
           </Grid>
           <Grid size={2}><Typography>Tags</Typography></Grid>

--- a/src/pages/grants/GrantOutputEditor.tsx
+++ b/src/pages/grants/GrantOutputEditor.tsx
@@ -21,12 +21,14 @@ export const GrantOutputEditor = ({
   fields,
   onChange,
   touchedFields = {},
-  onFieldBlur
+  onFieldBlur,
+  onEdit
 }: {
   fields: GrantOutput[],
   onChange: (updated: GrantOutput[]) => void,
   touchedFields?: Record<string, boolean>,
-  onFieldBlur?: (index: number, field: 'name' | 'maxWords') => void
+  onFieldBlur?: (index: number, field: 'name' | 'maxWords') => void,
+  onEdit?: () => void
 }) => {
 
   const [outputFields, setOutputFields] = useState<GrantOutput[]>(fields || []);
@@ -101,6 +103,7 @@ export const GrantOutputEditor = ({
                 error={Boolean(touchedFields[`name-${index}`]) && field.name.trim().length === 0}
                 helperText={Boolean(touchedFields[`name-${index}`]) && field.name.trim().length === 0 ? "Field name is required." : " "}
                 onBlur={() => onFieldBlur?.(index, 'name')}
+                onEdit={onEdit}
                 onChange={(e) => handleOutputFieldChange(index, 'name', e.target.value)}
               />
               <StableCursorTextField
@@ -111,6 +114,7 @@ export const GrantOutputEditor = ({
                 error={Boolean(touchedFields[`maxWords-${index}`]) && Number(field.maxWords) <= 0}
                 helperText={Boolean(touchedFields[`maxWords-${index}`]) && Number(field.maxWords) <= 0 ? "Enter a value greater than 0." : " "}
                 onBlur={() => onFieldBlur?.(index, 'maxWords')}
+                onEdit={onEdit}
                 onChange={(e) => handleOutputFieldChange(index, 'maxWords', parseInt(e.target.value) || 0)}
               />
               <ButtonGroup variant="contained" aria-label="Basic button group">

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -49,6 +49,7 @@ export const TextEditor = ({
   error = false,
   helperText,
   onBlur,
+  onEdit,
   subheader,
   helpTopic,
 }: {
@@ -59,6 +60,7 @@ export const TextEditor = ({
   error?: boolean,
   helperText?: string,
   onBlur?: () => void,
+  onEdit?: () => void,
   subheader?: string,
   helpTopic?: string,
 }) => {
@@ -82,6 +84,7 @@ export const TextEditor = ({
           error={error}
           helperText={helperText ?? " "}
           onBlur={onBlur}
+          onEdit={onEdit}
           multiline={true}
           sx={{
             '& .MuiInputBase-input': {
@@ -332,10 +335,13 @@ const GrantRecipesDetailPage: React.FC = () => {
   }
 
   function handleTemplateChange(updated: string): void {
-    grantRecipeService.updatePrompt({ ...recipe, template: updated })
+    const updatedRecipe = { ...recipe, template: updated };
+    setRecipe(updatedRecipe);
+    setDirty(true);
+
+    grantRecipeService.updatePrompt(updatedRecipe)
       .then(revised => {
         setRecipe(revised);
-        setDirty(true);
       })
   }
 
@@ -415,6 +421,7 @@ const GrantRecipesDetailPage: React.FC = () => {
                         onChange={handleInfoChange}
                         showDescriptionError={descriptionTouched && isDescriptionMissing}
                         onDescriptionBlur={() => setDescriptionTouched(true)}
+                        onEdit={() => setDirty(true)}
                       />
                       <TextEditor
                         title={RECIPE_STRINGS.templateTitle}
@@ -425,13 +432,19 @@ const GrantRecipesDetailPage: React.FC = () => {
                         error={templateTouched && isTemplateMissing}
                         helperText={templateTouched && isTemplateMissing ? "Template is required to generate." : " "}
                         onBlur={() => setTemplateTouched(true)}
+                        onEdit={() => setDirty(true)}
                       />
-                      <GrantContextEditor onChange={handleGrantContextsChange} onUploadingChange={setIsFileUploading} />
+                      <GrantContextEditor
+                        onChange={handleGrantContextsChange}
+                        onEdit={() => setDirty(true)}
+                        onUploadingChange={setIsFileUploading}
+                      />
                       <GrantOutputEditor
                         fields={recipe.outputsWithWordCount}
                         onChange={handleGrantOutputChange}
                         touchedFields={outputFieldTouched}
                         onFieldBlur={handleOutputFieldBlur}
+                        onEdit={() => setDirty(true)}
                       />
                       <PlainTextCard title={RECIPE_STRINGS.promptTitle} helpTopic="Prompt" value={recipe.prompt} />
                     </Stack>


### PR DESCRIPTION
## Description

  Fixes recipe form dirty state handling so the Save button enables immediately when a user edits a text field, without requiring the field to lose focus.

  Clicking into and out of an unchanged field does not enable Save. Field values continue to update on blur to preserve stable cursor behavior.

  ## What type of PR is this? (check all applicable)

  - [ ] Refactor
  - [ ] Feature
  - [x] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  ## Related Tickets & Documents

 https://digital-aid-seattle.atlassian.net/browse/WAVE-158

  ## QA Instructions, Screenshots, Recordings

  1. Open an existing recipe.
  2. Confirm Save is disabled.
  3. Type in the template field.
  4. Confirm Save enables immediately.
  5. Save and confirm the updated value persists.
  6. Click into an unchanged field, then click elsewhere.
  7. Confirm Save remains disabled.
  8. Repeat with the recipe title, context text, and output fields.