### PR TITLE
WAVE-107 & WAVE-171 - improve Copy All UX and rename Recipe Descripti…

### DIFF
--- a/src/pages/grants/GrantProposalsDetailPage.tsx
+++ b/src/pages/grants/GrantProposalsDetailPage.tsx
@@ -31,7 +31,10 @@ import Markdown from "react-markdown";
 import { PROPOSAL_LABELS } from "../../constants/labels";
 import { LoadingOverlay } from "../../components/LoadingOverlay";
 import { TextEdit } from "../../components/TextEdit";
-import { SUPPORTED_DOWNLOAD_TYPE } from "../../services/ProposalExporter";
+import {
+  SUPPORTED_DOWNLOAD_TYPE,
+  createProposalClipboardPlainText,
+} from "../../services/ProposalExporter";
 import { grantProposalService } from "../../services/grantProposalService";
 import { grantRecipeService } from "../../services/grantRecipeService";
 
@@ -41,6 +44,7 @@ import { DateUtils } from "../../utils/dateUtils";
 const LABELS = {
   ...PROPOSAL_LABELS,
   DOWNLOAD_TOOLTIP: "Download proposal",
+  COPY_ALL_TOOLTIP: "Copy the entire proposal with headings and sections preserved.",
 };
 
 function countWords(text: string): number {
@@ -295,6 +299,11 @@ const GrantProposalsDetailPage: React.FC = () => {
                       <DownloadOutlined />
                     </IconButton>
                   </Tooltip>
+                  <Tooltip title={LABELS.COPY_ALL_TOOLTIP}>
+                    <Box>
+                      <Clipboard text={createProposalClipboardPlainText(proposal)} />
+                    </Box>
+                  </Tooltip>
                   <Menu
                     id="download-menu"
                     anchorEl={anchorEl}
@@ -312,7 +321,6 @@ const GrantProposalsDetailPage: React.FC = () => {
                     <MenuItem onClick={() => handleDownload("docx")}>MS Word (.docx)</MenuItem>
                     <MenuItem onClick={() => handleDownload("pdf")}>PDF (.pdf)</MenuItem>
                   </Menu>
-                  <Clipboard text={Object.values(proposal.structuredResponse ?? {}).join("\n")} />
                 </Stack>
               }
             />

--- a/src/pages/grants/GrantRecipesListPage.tsx
+++ b/src/pages/grants/GrantRecipesListPage.tsx
@@ -114,7 +114,7 @@ const GrantRecipesListPage: React.FC = () => {
   const columns: GridColDef<GrantRecipe>[] = [
     {
       field: "description",
-      headerName: "Description",
+      headerName: "Recipe Name",
       width: 400,
     },
     {

--- a/src/services/ProposalExporter.test.ts
+++ b/src/services/ProposalExporter.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import type { GrantProposal } from "../types";
-import { ProposalExporter, type SUPPORTED_DOWNLOAD_TYPE } from "./ProposalExporter";
+import {
+  createMarkdownContent,
+  createProposalClipboardPlainText,
+  ProposalExporter,
+  type SUPPORTED_DOWNLOAD_TYPE,
+} from "./ProposalExporter";
 
 const buildProposal = (): GrantProposal => ({
   id: "proposal-1",
@@ -38,6 +43,26 @@ async function readBlobBuffer(blob: Blob): Promise<Buffer> {
 }
 
 describe("ProposalExporter", () => {
+  it("builds markdown content with structured proposal sections", () => {
+    const proposal = buildProposal();
+    const markdown = createMarkdownContent(proposal);
+
+    expect(markdown).toContain("# Community Garden Proposal");
+    expect(markdown).toContain("## Summary");
+    expect(markdown).toContain("## Impact");
+    expect(markdown).toContain("Build planters");
+  });
+
+  it("builds clipboard plain text with visible structure", () => {
+    const proposal = buildProposal();
+    const plainText = createProposalClipboardPlainText(proposal);
+
+    expect(plainText).toContain("Community Garden Proposal");
+    expect(plainText).toContain("Summary");
+    expect(plainText).toContain("Impact");
+    expect(plainText).toContain("Build planters");
+  });
+
   it.each([
     ["markdown", "Community Garden Proposal.md"],
     ["text", "Community Garden Proposal.txt"],

--- a/src/services/ProposalExporter.ts
+++ b/src/services/ProposalExporter.ts
@@ -15,15 +15,38 @@ type ExportBlock =
     | { type: "paragraph"; text: string }
     | { type: "blank"; text: string };
 
-function createMarkdownContent(proposal: GrantProposal): string {
+type ProposalSection = {
+    name: string;
+    value: string;
+};
+
+function getProposalSections(proposal: GrantProposal): ProposalSection[] {
+    return Object.entries(proposal.structuredResponse ?? {}).map(([name, value]) => ({
+        name,
+        value,
+    }));
+}
+
+export function createMarkdownContent(proposal: GrantProposal): string {
     let data = `# ${proposal.name}\n\n`;
 
-    Object.entries(proposal.structuredResponse ?? {}).forEach(entry => {
-        data += `## ${entry[0]}\n\n`;
-        data += entry[1] + "\n\n";
+    getProposalSections(proposal).forEach((entry) => {
+        data += `## ${entry.name}\n\n`;
+        data += `${entry.value}\n\n`;
     });
 
     return data;
+}
+
+export function createProposalClipboardPlainText(proposal: GrantProposal): string {
+    const sections = getProposalSections(proposal);
+    const lines = [proposal.name, ""];
+
+    sections.forEach((section) => {
+        lines.push(section.name, "", section.value, "");
+    });
+
+    return lines.join("\n").trimEnd();
 }
 
 function parseExportBlocks(content: string): ExportBlock[] {
@@ -72,14 +95,7 @@ class TextExporter extends AbstractExporter {
         return 'txt';
     }
     async createDownloadBlob(proposal: GrantProposal): Promise<Blob> {
-        let data = `${proposal.name}\n\n`;
-
-        Object.entries(proposal.structuredResponse ?? []).forEach(entry => {
-            data += entry[0] + "\n\n";
-            data += entry[1] + "\n\n";
-        });
-
-        return new Blob([data], { type: 'text/plain;charset=utf-8' });
+        return new Blob([createProposalClipboardPlainText(proposal)], { type: 'text/plain;charset=utf-8' });
     }
 }
 


### PR DESCRIPTION
## Description

### WAVE-107 
- The current “Copy All” action uses a copy icon that is visually identical to the “Copy Section” buttons. This can cause confusion for users, as it’s not immediately clear that this action copies the entire proposal rather than a single section.
- To make this action more intuitive, the Copy All control should include clearer affordances, such as:
- Descriptive hover text to clarify the action
- Copy the proposal with formatting preserved, ensuring structured output fields are included and visible when pasted

### WAVE-171
- The Grant Recipe List page currently displays a column labeled "Description", but the values shown in this column represent recipe names. To improve clarity and align the column header with the displayed data, update the column label from "Description" to "Recipe Name".

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## QA Instructions, Screenshots, Recordings
<img width="1315" height="457" alt="image" src="https://github.com/user-attachments/assets/a64911f3-d07d-4beb-9d1b-5cea7527b2aa" />
<img width="1245" height="335" alt="image" src="https://github.com/user-attachments/assets/1109f65b-8ac4-47d9-a04d-71a95eb8461d" />

## Acceptance Criteria
- Hover text of the topmost “Copy All” explicitly communicates that the action copies the entire proposal.
- Clicking “Copy All” copies the full proposal with formatting preserved
- All structured output fields (e.g., headings, sections, labels) are included and visible in the copied content
“Copy All” button will be directly next to the “Download” button

- Column Header Update:
Given a user is viewing the Grant Recipe List page, when the page loads,
Then the column currently labeled "Description" is displayed as "Recipe Name".