### PR TITLE
Require recipe names and prevent unsaved recipe creation

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -39,6 +39,7 @@ import {
   type MonthlyTokenUsagePoint,
   type TokenUsageSummary,
 } from '../../services/tokenUsageService';
+import { hasRecipeName } from '../../utils/recipeValidation';
 
 const numberFormatter = new Intl.NumberFormat();
 const compactNumberFormatter = new Intl.NumberFormat(undefined, {
@@ -131,7 +132,7 @@ const CloneRecipeCard = () => {
   }
 
   function handleClick() {
-    if (selectedRecipe) {
+    if (selectedRecipe && hasRecipeName(selectedRecipe)) {
       cloneRecipe(selectedRecipe)
         .then(recipe => navigate(`/grant-recipes/${recipe.id}`))
     }
@@ -150,7 +151,7 @@ const CloneRecipeCard = () => {
         </Select>
       </CardContent>
       <CardActions>
-        <Button variant="contained" disabled={!selectedRecipe} onClick={handleClick}>Clone</Button>
+        <Button variant="contained" disabled={!selectedRecipe || !hasRecipeName(selectedRecipe)} onClick={handleClick}>Clone</Button>
       </CardActions>
     </Card >
   )
@@ -164,7 +165,7 @@ const CreateRecipeCard = () => {
     if (loading) return;
     setLoading(true);
     createRecipe()
-      .then(recipe => navigate(`/grant-recipes/${recipe.id}`))
+      .then(() => navigate('/grant-recipes/new'))
       .finally(() => setLoading(false));
   }
 

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -39,7 +39,7 @@ import {
   type MonthlyTokenUsagePoint,
   type TokenUsageSummary,
 } from '../../services/tokenUsageService';
-import { hasRecipeName } from '../../utils/recipeValidation';
+import { isValidRecipe } from '../../utils/recipeValidation';
 
 const numberFormatter = new Intl.NumberFormat();
 const compactNumberFormatter = new Intl.NumberFormat(undefined, {
@@ -132,7 +132,7 @@ const CloneRecipeCard = () => {
   }
 
   function handleClick() {
-    if (selectedRecipe && hasRecipeName(selectedRecipe)) {
+    if (isValidRecipe(selectedRecipe, recipes)) {
       cloneRecipe(selectedRecipe)
         .then(recipe => navigate(`/grant-recipes/${recipe.id}`))
     }
@@ -151,7 +151,7 @@ const CloneRecipeCard = () => {
         </Select>
       </CardContent>
       <CardActions>
-        <Button variant="contained" disabled={!selectedRecipe || !hasRecipeName(selectedRecipe)} onClick={handleClick}>Clone</Button>
+        <Button variant="contained" disabled={!isValidRecipe(selectedRecipe, recipes)} onClick={handleClick}>Clone</Button>
       </CardActions>
     </Card >
   )

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -138,17 +138,17 @@ const GrantRecipesDetailPage: React.FC = () => {
   const [isFileUploading, setIsFileUploading] = useState<boolean>(false);
 
   const shouldBlockNavigation = useCallback(
-    () => !id && !allowNavigationRef.current,
-    [id]
+    () => dirty && !allowNavigationRef.current,
+    [dirty]
   );
   const navigationBlocker = useBlocker(shouldBlockNavigation);
 
   useBeforeUnload(useCallback((event: BeforeUnloadEvent) => {
-    if (!id && !allowNavigationRef.current) {
+    if (dirty && !allowNavigationRef.current) {
       event.preventDefault();
       event.returnValue = "";
     }
-  }, [id]));
+  }, [dirty]));
 
   const hasValidDescription = hasRecipeName(recipe);
   const isDescriptionMissing = !hasValidDescription;
@@ -176,6 +176,8 @@ const GrantRecipesDetailPage: React.FC = () => {
   }, [recipe?.template]);
 
   useEffect(() => {
+    allowNavigationRef.current = false;
+
     if (id) {
       grantRecipeService.getById(id)
         .then(found => {
@@ -521,8 +523,11 @@ const GrantRecipesDetailPage: React.FC = () => {
                     handleCancel={handleDeleteCancel}
                   />
                   <ConfirmationDialog
-                    title="Discard unsaved recipe?"
-                    message="This recipe has not been saved. Are you sure you want to leave this page?"
+                    title={recipe.id ? "Discard unsaved changes?" : "Discard unsaved recipe?"}
+                    message={recipe.id
+                      ? "You have unsaved changes. Are you sure you want to leave this page?"
+                      : "This recipe has not been saved. Are you sure you want to leave this page?"
+                    }
                     open={navigationBlocker.state === "blocked"}
                     handleConfirm={() => navigationBlocker.state === "blocked" && navigationBlocker.proceed()}
                     handleCancel={() => navigationBlocker.state === "blocked" && navigationBlocker.reset()}

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -25,6 +25,7 @@ import { generateProposal } from "../../transactions/GenerateProposal";
 import { saveRecipe } from "../../transactions/SaveRecipe";
 import { GrantOutput, GrantRecipe, Timestamp } from "../../types";
 import { DateUtils } from "../../utils/dateUtils";
+import { hasRecipeName } from "../../utils/recipeValidation";
 import { GrantAiService } from "./grantAiService";
 import { GrantContextEditor } from "./GrantContextEditor";
 import { GrantInfoEditor } from "./GrantInfoEditor";
@@ -122,7 +123,6 @@ const GrantRecipesDetailPage: React.FC = () => {
   const [dirty, setDirty] = useState<boolean>(false);
   const { showHelp } = useHelp();
   const [helpTopic, setHelpTopic] = useState<string | undefined>();
-  const [hasValidDescription, setHasValidDescription] = useState<boolean>(false);
   const [hasCompleteOutputFields, setHasCompleteOutputFields] = useState<boolean>(false);
   const [hasValidTemplate, setHasValidTemplate] = useState<boolean>(false);
   const [descriptionTouched, setDescriptionTouched] = useState<boolean>(false);
@@ -133,6 +133,7 @@ const GrantRecipesDetailPage: React.FC = () => {
   const [rating, setRating] = useState<number>(0);
   const [isFileUploading, setIsFileUploading] = useState<boolean>(false);
 
+  const hasValidDescription = hasRecipeName(recipe);
   const isDescriptionMissing = !hasValidDescription;
   const isOutputFieldsIncomplete = !hasCompleteOutputFields;
   const isTemplateMissing = !hasValidTemplate;
@@ -144,10 +145,6 @@ const GrantRecipesDetailPage: React.FC = () => {
   if (!loading && hasValidDescription && !dirty) {
     actionMessages.push("Make a change to enable Save.");
   }
-
-  useEffect(() => {
-    setHasValidDescription((recipe?.description ?? "").trim().length > 0);
-  }, [recipe?.description]);
 
   useEffect(() => {
     const outputs = recipe?.outputsWithWordCount ?? [];
@@ -193,11 +190,15 @@ const GrantRecipesDetailPage: React.FC = () => {
       notifications.error("Please name your recipe before saving.");
       return;
     }
+    const isNewRecipe = !recipe.id;
     setLoading(true);
     saveRecipe(recipe)
       .then(saved => {
         setRecipe(saved);
         setDirty(false);
+        if (isNewRecipe) {
+          navigate(`/grant-recipes/${saved.id}`, { replace: true });
+        }
         notifications.success(`${saved.description} has been successfully saved.`)
       })
       .catch(err => {
@@ -472,7 +473,7 @@ const GrantRecipesDetailPage: React.FC = () => {
                         color="error"
                         startIcon={<DeleteIcon />}
                         onClick={handleDeleteClick}
-                        disabled={loading || isDeleting}
+                        disabled={loading || isDeleting || !recipe.id}
                       >
                         Delete
                       </Button>

--- a/src/pages/grants/GrantRecipesDetailPage.tsx
+++ b/src/pages/grants/GrantRecipesDetailPage.tsx
@@ -3,8 +3,8 @@
  * 
  * @copyright 2025 Digital Aid Seattle
 */
-import { useContext, useEffect, useState } from "react";
-import { NavLink, useNavigate, useParams } from "react-router-dom";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { NavLink, useBeforeUnload, useBlocker, useNavigate, useParams } from "react-router-dom";
 
 import { HomeOutlined, InfoCircleOutlined } from "@ant-design/icons";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -117,6 +117,7 @@ const GrantRecipesDetailPage: React.FC = () => {
   const notifications = useNotifications();
   const navigate = useNavigate();
   const { loading, setLoading } = useContext(LoadingContext);
+  const allowNavigationRef = useRef(false);
 
   const [recipe, setRecipe] = useState<GrantRecipe>(grantRecipeService.empty());
   const [lastUpdated, setLastUpdated] = useState<string>("");
@@ -132,6 +133,19 @@ const GrantRecipesDetailPage: React.FC = () => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [rating, setRating] = useState<number>(0);
   const [isFileUploading, setIsFileUploading] = useState<boolean>(false);
+
+  const shouldBlockNavigation = useCallback(
+    () => !id && !allowNavigationRef.current,
+    [id]
+  );
+  const navigationBlocker = useBlocker(shouldBlockNavigation);
+
+  useBeforeUnload(useCallback((event: BeforeUnloadEvent) => {
+    if (!id && !allowNavigationRef.current) {
+      event.preventDefault();
+      event.returnValue = "";
+    }
+  }, [id]));
 
   const hasValidDescription = hasRecipeName(recipe);
   const isDescriptionMissing = !hasValidDescription;
@@ -197,6 +211,7 @@ const GrantRecipesDetailPage: React.FC = () => {
         setRecipe(saved);
         setDirty(false);
         if (isNewRecipe) {
+          allowNavigationRef.current = true;
           navigate(`/grant-recipes/${saved.id}`, { replace: true });
         }
         notifications.success(`${saved.description} has been successfully saved.`)
@@ -218,6 +233,7 @@ const GrantRecipesDetailPage: React.FC = () => {
     setLoading(true);
     cloneRecipe(recipe)
       .then(cloned => {
+        allowNavigationRef.current = true;
         navigate(`/grant-recipes/${cloned.id}`);
         notifications.success(`${recipe.description} has been successfully cloned.`)
       })
@@ -250,6 +266,7 @@ const GrantRecipesDetailPage: React.FC = () => {
       generateProposal(recipe)
         .then(proposal => {
           notifications.success(`Proposal generated for ${recipe.description}.`);
+          allowNavigationRef.current = true;
           navigate(`/grant-proposals/${proposal.id}`);
         })
         .catch((err: unknown) => {
@@ -489,6 +506,13 @@ const GrantRecipesDetailPage: React.FC = () => {
                     open={openDeleteDialog}
                     handleConfirm={handleDeleteConfirm}
                     handleCancel={handleDeleteCancel}
+                  />
+                  <ConfirmationDialog
+                    title="Discard unsaved recipe?"
+                    message="This recipe has not been saved. Are you sure you want to leave this page?"
+                    open={navigationBlocker.state === "blocked"}
+                    handleConfirm={() => navigationBlocker.state === "blocked" && navigationBlocker.proceed()}
+                    handleCancel={() => navigationBlocker.state === "blocked" && navigationBlocker.reset()}
                   />
                 </Card>
               </Stack>

--- a/src/pages/grants/GrantRecipesListPage.tsx
+++ b/src/pages/grants/GrantRecipesListPage.tsx
@@ -11,6 +11,7 @@ import { cloneRecipe } from "../../transactions/CloneRecipe";
 import { createRecipe } from "../../transactions/CreateRecipe";
 import type { GrantRecipe, Timestamp } from "../../types";
 import { DateUtils } from "../../utils/dateUtils";
+import { hasRecipeName } from "../../utils/recipeValidation";
 
 const GrantRecipesListPage: React.FC = () => {
   const notifications = useNotifications();
@@ -70,18 +71,25 @@ const GrantRecipesListPage: React.FC = () => {
 
   const handleAdd = async () => {
     createRecipe()
-      .then(recipe => navigate(`/grant-recipes/${recipe.id}`))
+      .then(() => navigate("/grant-recipes/new"))
   }
 
   const handleClone = async () => {
     const recipe = recipes.find(r => r.id === selectedIds[0]);
-    if (recipe) {
-      const inserted = await cloneRecipe(recipe);
-      navigate(`/grant-recipes/${inserted.id}`);
+    if (recipe && hasRecipeName(recipe)) {
+      try {
+        const inserted = await cloneRecipe(recipe);
+        navigate(`/grant-recipes/${inserted.id}`);
+      } catch (error) {
+        notifications.error(`Failed to clone the recipe: ${error instanceof Error ? error.message : "Unknown error"}`);
+      }
     } else {
-      notifications.error(`Failed to clone the recipe.`);
+      notifications.error("A named recipe must be selected before cloning.");
     }
   }
+
+  const selectedRecipe = recipes.find(recipe => recipe.id === selectedIds[0]);
+  const isCloneDisabled = selectedIds.length !== 1 || !selectedRecipe || !hasRecipeName(selectedRecipe);
 
   function handleRowSelection(model: GridRowSelectionModel) {
     if (!model) return;
@@ -189,7 +197,7 @@ const GrantRecipesListPage: React.FC = () => {
           <Box>
             <IconButton color="primary"
               onClick={handleClone}
-              disabled={selectedIds.length !== 1} >
+              disabled={isCloneDisabled} >
               <CopyOutlined />
             </IconButton>
           </Box>

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -27,6 +27,10 @@ const routes = [
         element: <GrantRecipesListPage />,
       },
       {
+        path: "grant-recipes/new",
+        element: <GrantRecipesDetailPage />,
+      },
+      {
         path: "grant-recipes/:id",
         element: <GrantRecipesDetailPage />,
       },

--- a/src/services/grantRecipeService.test.ts
+++ b/src/services/grantRecipeService.test.ts
@@ -1,51 +1,56 @@
 import { describe, expect, it, vi } from "vitest";
-import { GrantRecipe } from "../types";
+import type { GrantRecipe } from "../types";
+
+vi.mock("../App", () => ({
+  authService: { getUser: vi.fn() },
+}));
+
+vi.mock("./settingsService", () => ({
+  SettingsService: {
+    getInstance: () => ({
+      getSettings: vi.fn().mockResolvedValue({
+        outputTemplate: "",
+        lowerBoundPercentage: 0.5,
+      }),
+    }),
+  },
+}));
+
 import { grantRecipeService } from "./grantRecipeService";
-import { geminiService } from "../api/geminiService";
 
 describe("grantRecipeService", () => {
-
-  vi.mock('../api/geminiService', () => ({
-    geminiService: ({
-      calcTokenCount: () => { }
-    }),
-  }));
-
-  it("generatePromptWithInputs", () => {
-
+  it("generates a prompt with output word-count bounds", async () => {
     const recipe = {
-      prompt: "Create a grant proposal including the following information:\n {{#each inputs}}{{key}} = {{value}},\n{{/each}}"
-        + " where{{#each outputs}}{{#unless @first}} and{{/unless}} the output {{name}} is constrained by a maximum {{maxWords}} of {{unit}} {{/each}}.",
-      inputParameters: [
-        { key: "organizationName", value: "Our Wave" },
-        { key: "projectDescription", value: "Community garden for local residents" },
-        { key: "requestedAmount", value: "$5000" }
-      ],
+      template: "Write {{#each outputs}}{{name}} {{lowerBound}}-{{upperBound}}{{/each}}",
       outputsWithWordCount: [
-        { name: "Executive Summary", maxWords: 200, unit: "words" },
-        { name: "Mission Statement", maxWords: 400, unit: "words" },
-      ]
-    } as unknown as GrantRecipe;
+        { name: "Summary", maxWords: 200, unit: "words" },
+      ],
+    } as GrantRecipe;
 
-    const result = grantRecipeService.generatePromptWithInputs(recipe)
-    console.log(result);
-  })
+    await expect(grantRecipeService.generatePromptWithInputs(recipe)).resolves.toBe(
+      "Write Summary 100-200"
+    );
+  });
 
-  it("updatePrompt", () => {
-
+  it("updates the local compiled prompt without persisting", async () => {
     const recipe = {
-      modelType: 'GEMINI',
-      prompt: "Create a grant proposal including the following information:",
-      inputParameters: []
-    } as unknown as GrantRecipe;
+      description: "Named recipe",
+      template: "Write {{#each outputs}}{{name}}{{/each}}",
+      outputsWithWordCount: [
+        { name: "Summary", maxWords: 200, unit: "words" },
+      ],
+      prompt: "old prompt",
+      tokenCount: 5,
+    } as GrantRecipe;
 
-    const tokenSpy = vi.spyOn(geminiService, "calcTokenCount").mockResolvedValue(5);
+    await expect(grantRecipeService.updatePrompt(recipe)).resolves.toEqual(
+      expect.objectContaining({ prompt: "Write Summary", tokenCount: 5 })
+    );
+  });
 
-    grantRecipeService.updatePrompt(recipe)
-      .then(updated => {
-        expect(tokenSpy).toBeCalledWith("GEMINI", "Create a grant proposal including the following information:[]");
-        expect(updated.tokenCount).toBe(5)
-      })
-  })
-
+  it("rejects unnamed recipes before inserting them", async () => {
+    await expect(
+      grantRecipeService.insert({ description: " " } as GrantRecipe)
+    ).rejects.toThrow("Recipe name is required to save.");
+  });
 });

--- a/src/services/grantRecipeService.ts
+++ b/src/services/grantRecipeService.ts
@@ -4,6 +4,7 @@ import Handlebars from "handlebars";
 import { authService } from "../App";
 import { FIRESTORE_COLLECTIONS } from "../constants/firestoreCollections";
 import type { GrantRecipe } from "../types";
+import { requireRecipeName } from "../utils/recipeValidation";
 import { SettingsService } from "./settingsService";
 
 class GrantRecipeService extends FirestoreService<GrantRecipe> {
@@ -47,6 +48,8 @@ class GrantRecipeService extends FirestoreService<GrantRecipe> {
     mapper?: (json: any) => GrantRecipe,
     user?: User
   ): Promise<GrantRecipe> {
+    requireRecipeName(entity, "save");
+
     const sessionUser = user ?? await authService.getUser();
     if (!sessionUser?.email) {
       throw new Error("grantRecipeService.insert: user.email is required");
@@ -93,6 +96,7 @@ class GrantRecipeService extends FirestoreService<GrantRecipe> {
     mapper?: (json: any) => GrantRecipe,
     user?: User
   ): Promise<GrantRecipe> {
+    requireRecipeName(updatedFields, "save");
 
     const sessionUser = user ?? await authService.getUser();
     if (!sessionUser) {

--- a/src/services/grantRecipeService.ts
+++ b/src/services/grantRecipeService.ts
@@ -70,19 +70,26 @@ class GrantRecipeService extends FirestoreService<GrantRecipe> {
     }
     delete cleaned.id;
 
-    return super.insert(
-      {
-        ...cleaned,
-        prompt,
-        createdAt: now,
-        createdBy: sessionUser.email,
-        updatedAt: now,
-        updatedBy: sessionUser.email,
-      } as GrantRecipe,
+    const savedRecipe = {
+      ...cleaned,
+      prompt,
+      createdAt: now,
+      createdBy: sessionUser.email,
+      updatedAt: now,
+      updatedBy: sessionUser.email,
+    } as GrantRecipe;
+
+    const inserted = await super.insert(
+      savedRecipe,
       select,
       mapper,
       user
     );
+
+    return {
+      ...savedRecipe,
+      id: inserted.id,
+    };
   }
 
   /**

--- a/src/transactions/CloneRecipe.test.ts
+++ b/src/transactions/CloneRecipe.test.ts
@@ -1,40 +1,46 @@
-/**
- *  CreateRecipe.test.ts
- *
- *  @copyright 2024 Digital Aid Seattle
- *
- */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { User } from "@digitalaidseattle/core";
+import type { GrantRecipe } from "../types";
 
-import { describe, expect, it, vi } from "vitest";
-import { User } from "@digitalaidseattle/core";
+vi.mock("../App", () => ({
+  authService: { getUser: vi.fn() },
+}));
+
+vi.mock("../services/grantRecipeService", () => ({
+  grantRecipeService: { insert: vi.fn() },
+}));
+
 import { authService } from "../App";
 import { grantRecipeService } from "../services/grantRecipeService";
-import { GrantRecipe } from "../types";
 import { cloneRecipe } from "./CloneRecipe";
 
 describe("cloneRecipe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    vi.mock('../api/geminiService', () => ({
-        geminiService: ({
-            calcTokenCount: () => { }
-        }),
+  it("clones a named recipe", async () => {
+    const user = { email: "email@me.com" } as User;
+    const recipe = { description: "desc" } as GrantRecipe;
+    const inserted = { id: "clone-id" } as GrantRecipe;
+    vi.mocked(authService.getUser).mockResolvedValue(user);
+    vi.mocked(grantRecipeService.insert).mockResolvedValue(inserted);
+
+    await expect(cloneRecipe(recipe)).resolves.toBe(inserted);
+
+    expect(grantRecipeService.insert).toHaveBeenCalledWith(expect.objectContaining({
+      description: "Clone of desc",
+      createdBy: "email@me.com",
+      updatedBy: "email@me.com",
     }));
+  });
 
-    it("cloneRecipe", () => {
-        const user = { email: 'email@me.com' } as User;
-        const recipe = { description: 'desc' } as GrantRecipe;
-        const inserted = {} as GrantRecipe;
+  it("rejects a blank recipe name before persistence", async () => {
+    await expect(cloneRecipe({ description: "  " } as GrantRecipe)).rejects.toThrow(
+      "Recipe name is required to clone."
+    );
 
-        const userSpy = vi.spyOn(authService, "getUser").mockResolvedValue(user);
-        const insertSpy = vi.spyOn(grantRecipeService, "insert").mockResolvedValue(inserted);
-
-        cloneRecipe(recipe).then(actual => {
-            expect(userSpy).toHaveBeenCalledOnce();
-            expect(insertSpy).toHaveBeenCalledOnce();
-            expect(insertSpy).toHaveBeenCalledWith(expect.
-                objectContaining({ description: 'Clone of desc', createdBy: 'email@me.com', updatedBy: 'email@me.com' }));
-            expect(actual).toBe(inserted);
-        });
-    });
-
+    expect(authService.getUser).not.toHaveBeenCalled();
+    expect(grantRecipeService.insert).not.toHaveBeenCalled();
+  });
 });

--- a/src/transactions/CloneRecipe.ts
+++ b/src/transactions/CloneRecipe.ts
@@ -8,8 +8,11 @@
 import { grantRecipeService } from "../services/grantRecipeService";
 import { GrantRecipe } from "../types";
 import { authService } from "../App";
+import { requireRecipeName } from "../utils/recipeValidation";
 
 export async function cloneRecipe(recipe: GrantRecipe): Promise<GrantRecipe> {
+    requireRecipeName(recipe, "clone");
+
     return authService.getUser()
         .then(user => {
             const now = new Date();

--- a/src/transactions/CreateRecipe.test.ts
+++ b/src/transactions/CreateRecipe.test.ts
@@ -1,40 +1,28 @@
-/**
- *  CreateRecipe.test.ts
- *
- *  @copyright 2024 Digital Aid Seattle
- *
- */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GrantRecipe } from "../types";
 
-import { describe, expect, it, vi } from "vitest";
+vi.mock("../services/grantRecipeService", () => ({
+  grantRecipeService: {
+    empty: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
 import { grantRecipeService } from "../services/grantRecipeService";
-import { GrantRecipe } from "../types";
 import { createRecipe } from "./CreateRecipe";
-import { authService } from "../App";
-import { User } from "@digitalaidseattle/core";
 
 describe("createRecipe", () => {
-    vi.mock('../api/geminiService', () => ({
-        geminiService: ({
-            calcTokenCount: () => { }
-        }),
-    }));
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    it("createRecipe", () => {
-        const user = {} as User;
-        const recipe = {} as GrantRecipe;
-        const inserted = {} as GrantRecipe;
+  it("returns a blank local recipe without persisting it", async () => {
+    const recipe = { description: "" } as GrantRecipe;
+    vi.mocked(grantRecipeService.empty).mockReturnValue(recipe);
 
-        const userSpy = vi.spyOn(authService, "getUser").mockResolvedValue(user);
-        const emptySpy = vi.spyOn(grantRecipeService, "empty").mockReturnValue(recipe);
-        const insertSpy = vi.spyOn(grantRecipeService, "insert").mockResolvedValue(inserted);
+    await expect(createRecipe()).resolves.toBe(recipe);
 
-        createRecipe().then(actual => {
-            expect(userSpy).toHaveBeenCalledOnce();
-            expect(emptySpy).toHaveBeenCalledOnce();
-            expect(insertSpy).toHaveBeenCalledOnce();
-            expect(recipe.description.startsWith('Recipe')).toBe(true);
-            expect(actual).toBe(inserted)
-        });
-    });
-
+    expect(grantRecipeService.empty).toHaveBeenCalledOnce();
+    expect(grantRecipeService.insert).not.toHaveBeenCalled();
+  });
 });

--- a/src/transactions/CreateRecipe.ts
+++ b/src/transactions/CreateRecipe.ts
@@ -5,15 +5,9 @@
  *
  */
 
-import { authService } from "../App";
 import { grantRecipeService } from "../services/grantRecipeService";
 import { GrantRecipe } from "../types";
-// import { DateUtils } from "../utils/dateUtils";
 
 export function createRecipe(): Promise<GrantRecipe> {
-    return authService.getUser()
-        .then((user => {
-            const newRecipe = grantRecipeService.empty();
-            return grantRecipeService.insert(newRecipe, undefined, undefined, user);
-        }))
+    return Promise.resolve(grantRecipeService.empty());
 }

--- a/src/transactions/GenerateProposal.test.ts
+++ b/src/transactions/GenerateProposal.test.ts
@@ -1,97 +1,108 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { GrantRecipe } from "../types";
+import type { GrantProposal, GrantRecipe } from "../types";
 
-// Mock AI service
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  parameterizedQuery: vi.fn(),
+  recipeInsert: vi.fn(),
+  recipeUpdate: vi.fn(),
+  proposalInsert: vi.fn(),
+}));
+
+vi.mock("../App", () => ({
+  authService: { getUser: mocks.getUser },
+}));
+
 vi.mock("../pages/grants/grantAiService", () => ({
-  grantAiService: {
-    parameterizedQuery: vi.fn(),
+  GrantAiService: class {
+    static getInstance() {
+      return { parameterizedQuery: mocks.parameterizedQuery };
+    }
   },
 }));
 
-// Mock Firebase
-vi.mock("@digitalaidseattle/firebase", () => ({
-  firebaseClient: { app: {} },
-  FirestoreService: class { },
+vi.mock("../services/grantRecipeService", () => ({
+  grantRecipeService: {
+    insert: mocks.recipeInsert,
+    update: mocks.recipeUpdate,
+  },
 }));
 
-import { GrantAiService } from "../pages/grants/grantAiService";
+vi.mock("../services/grantProposalService", () => ({
+  grantProposalService: {
+    empty: () => ({}),
+    insert: mocks.proposalInsert,
+  },
+}));
+
 import { generateProposal } from "./GenerateProposal";
 
-describe("GenerateProposal", () => {
-  const grantAiService = GrantAiService.getInstance();
+const namedRecipe = (): GrantRecipe => ({
+  id: "recipe-123",
+  createdAt: new Date(),
+  createdBy: "tester@example.com",
+  updatedAt: new Date(),
+  updatedBy: "tester@example.com",
+  lastSubmitted: null,
+  description: "Test recipe",
+  tags: [],
+  rating: 0,
+  template: "Test template",
+  prompt: "compiled prompt",
+  contexts: [],
+  outputsWithWordCount: [
+    { name: "Summary", maxWords: 3, unit: "words" },
+    { name: "Notes", maxWords: 10, unit: "characters" },
+  ],
+  inputParameters: [],
+  tokenCount: 0,
+  modelType: "gemini-2.5-flash",
+});
 
+describe("generateProposal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("builds structuredResponse from AI output", async () => {
-    const recipe: GrantRecipe = {
-      id: "recipe-123",
-      createdAt: new Date(),
-      createdBy: "tester@example.com",
-      updatedAt: new Date(),
-      updatedBy: "tester@example.com",
-      lastSubmitted: null,
-      description: "Test recipe",
-      tags: [],
-      rating: 0,
-      template: "Test {{#each outputs}}{{name}} {{/each}}",
-      prompt: "compiled prompt",
-      contexts: [],
-      outputsWithWordCount: [
-        { name: "Summary", maxWords: 3, unit: "words" },
-        { name: "Notes", maxWords: 10, unit: "characters" },
-      ],
-      inputParameters: [],
-      tokenCount: 0,
-      modelType: "gemini-2.5-flash",
-    };
-
-    (grantAiService.parameterizedQuery as any).mockResolvedValue({
-      Summary: "This should be trimmed",
-      Notes: "abcdefghijklmnop",
+  it("builds a proposal from the AI response", async () => {
+    const recipe = namedRecipe();
+    const savedRecipe = { ...recipe, lastSubmitted: new Date() };
+    const insertedProposal = { id: "proposal-1" } as GrantProposal;
+    mocks.getUser.mockResolvedValue({ email: "tester@example.com" });
+    mocks.recipeUpdate.mockResolvedValue(savedRecipe);
+    mocks.parameterizedQuery.mockResolvedValue({
+      text: JSON.stringify({ Summary: "Summary text", Notes: "Notes text" }),
+      usageMetadata: { totalTokenCount: 42 },
     });
+    mocks.proposalInsert.mockResolvedValue(insertedProposal);
 
-    const proposal = await generateProposal(recipe);
+    await expect(generateProposal(recipe)).resolves.toBe(insertedProposal);
 
-    expect(grantAiService.parameterizedQuery).toHaveBeenCalledTimes(1);
-    expect(proposal.grantRecipeId).toBe("recipe-123");
-
-    // AI output is preserved as-is
-    expect(proposal.structuredResponse?.Summary).toBe("This should be trimmed");
-    expect(proposal.structuredResponse?.Notes).toBe("abcdefghijklmnop");
+    expect(mocks.parameterizedQuery).toHaveBeenCalledOnce();
+    expect(mocks.proposalInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        grantRecipeId: "recipe-123",
+        structuredResponse: { Summary: "Summary text", Notes: "Notes text" },
+        totalTokenCount: 42,
+      }),
+      undefined,
+      undefined,
+      { email: "tester@example.com" }
+    );
   });
 
-  it("throws if recipe has no id", async () => {
-    await expect(
-      generateProposal({
-        outputsWithWordCount: [{ name: "Test", maxWords: 3, unit: "words" }],
-      } as any)
-    ).rejects.toThrow("Recipe ID is required");
+  it("rejects a blank recipe name before saving or calling AI", async () => {
+    await expect(generateProposal({ ...namedRecipe(), description: " " })).rejects.toThrow(
+      "Recipe name is required to generate a proposal."
+    );
+
+    expect(mocks.recipeUpdate).not.toHaveBeenCalled();
+    expect(mocks.parameterizedQuery).not.toHaveBeenCalled();
   });
 
-  it("throws if outputsWithWordCount is empty", async () => {
-    const badRecipe: GrantRecipe = {
-      id: "no-outputs",
-      createdAt: new Date(),
-      createdBy: "",
-      updatedAt: new Date(),
-      updatedBy: "",
-      lastSubmitted: null,
-      description: "",
-      tags: [],
-      rating: 0,
-      template: "",
-      prompt: "",
-      contexts: [],
-      outputsWithWordCount: [],
-      tokenCount: 0,
-      inputParameters: [],
-      modelType: "gemini-2.5-flash",
-    };
-
-    await expect(
-      generateProposal(badRecipe)
-    ).rejects.toThrow("Recipe is missing output fields");
+  it("rejects a recipe without output fields", async () => {
+    await expect(generateProposal({ ...namedRecipe(), outputsWithWordCount: [] })).rejects.toThrow(
+      "Recipe is missing output fields"
+    );
   });
 });

--- a/src/transactions/GenerateProposal.ts
+++ b/src/transactions/GenerateProposal.ts
@@ -10,8 +10,11 @@ import { GrantAiService } from "../pages/grants/grantAiService";
 import { grantProposalService } from "../services/grantProposalService";
 import { grantRecipeService } from "../services/grantRecipeService";
 import { GrantProposal, GrantRecipe } from "../types";
+import { requireRecipeName } from "../utils/recipeValidation";
 
 export async function generateProposal(recipe: GrantRecipe): Promise<GrantProposal> {
+    requireRecipeName(recipe, "generate a proposal");
+
     const grantAiService = GrantAiService.getInstance();
 
     const outputs = recipe.outputsWithWordCount ?? [];
@@ -34,7 +37,6 @@ export async function generateProposal(recipe: GrantRecipe): Promise<GrantPropos
         ...recipe,
         lastSubmitted: now
     }
-    console.log(updatedRecipe);
 
     let savedRecipe: GrantRecipe;
     if (recipe.id) {

--- a/src/transactions/SaveRecipe.ts
+++ b/src/transactions/SaveRecipe.ts
@@ -8,6 +8,7 @@
 import { authService, storageService } from "../App";
 import { grantRecipeService } from "../services/grantRecipeService";
 import { GrantContext, GrantRecipe } from "../types";
+import { requireRecipeName } from "../utils/recipeValidation";
 
 const GLOUD_FOLDER = import.meta.env.VITE_FIREBASE_STORAGE_FOLDER;
 
@@ -40,6 +41,8 @@ async function uploadFiles(contexts: GrantContext[]): Promise<GrantContext[]> {
 
 
 export async function saveRecipe(recipe: GrantRecipe): Promise<GrantRecipe> {
+    requireRecipeName(recipe, "save");
+
     return authService.getUser()
         .then((async user => {
             const prompt = await grantRecipeService.generatePromptWithInputs(recipe);
@@ -58,4 +61,3 @@ export async function saveRecipe(recipe: GrantRecipe): Promise<GrantRecipe> {
             }
         }))
 }
-

--- a/src/transactions/SaveRecipe.ts
+++ b/src/transactions/SaveRecipe.ts
@@ -55,9 +55,9 @@ export async function saveRecipe(recipe: GrantRecipe): Promise<GrantRecipe> {
             }
 
             if (recipe.id) {
-                return grantRecipeService.update(recipe.id, newRecipe, user);
+                return grantRecipeService.update(recipe.id, newRecipe, undefined, undefined, user);
             } else {
-                return grantRecipeService.insert(newRecipe, user);
+                return grantRecipeService.insert(newRecipe, undefined, undefined, user);
             }
         }))
 }

--- a/src/utils/recipeValidation.test.ts
+++ b/src/utils/recipeValidation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { hasRecipeName, requireRecipeName } from "./recipeValidation";
+
+describe("recipe name validation", () => {
+  it.each(["", "   ", "\n\t"])("rejects an empty recipe name", description => {
+    expect(hasRecipeName({ description })).toBe(false);
+    expect(() => requireRecipeName({ description }, "save")).toThrow(
+      "Recipe name is required to save."
+    );
+  });
+
+  it("accepts free text with surrounding whitespace", () => {
+    expect(hasRecipeName({ description: "  Community grant  " })).toBe(true);
+    expect(() => requireRecipeName({ description: "Recipe" }, "clone")).not.toThrow();
+  });
+});

--- a/src/utils/recipeValidation.test.ts
+++ b/src/utils/recipeValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hasRecipeName, requireRecipeName } from "./recipeValidation";
+import { hasRecipeName, hasUniqueRecipeName, isValidRecipe, requireRecipeName } from "./recipeValidation";
 
 describe("recipe name validation", () => {
   it.each(["", "   ", "\n\t"])("rejects an empty recipe name", description => {
@@ -12,5 +12,26 @@ describe("recipe name validation", () => {
   it("accepts free text with surrounding whitespace", () => {
     expect(hasRecipeName({ description: "  Community grant  " })).toBe(true);
     expect(() => requireRecipeName({ description: "Recipe" }, "clone")).not.toThrow();
+  });
+
+  it("rejects duplicate recipe names case-insensitively", () => {
+    const recipes = [
+      { id: "recipe-1", description: "Community grant" },
+      { id: "recipe-2", description: "Capital campaign" },
+    ];
+
+    expect(hasUniqueRecipeName({ id: "recipe-3", description: " community GRANT " }, recipes)).toBe(false);
+    expect(hasUniqueRecipeName({ id: "recipe-1", description: "Community grant" }, recipes)).toBe(true);
+  });
+
+  it("validates a recipe with null, name, and uniqueness checks", () => {
+    const recipes = [
+      { id: "recipe-1", description: "Community grant" },
+    ];
+
+    expect(isValidRecipe(undefined, recipes)).toBe(false);
+    expect(isValidRecipe({ id: "recipe-2", description: " " }, recipes)).toBe(false);
+    expect(isValidRecipe({ id: "recipe-2", description: "Community grant" }, recipes)).toBe(false);
+    expect(isValidRecipe({ id: "recipe-2", description: "Operating support" }, recipes)).toBe(true);
   });
 });

--- a/src/utils/recipeValidation.ts
+++ b/src/utils/recipeValidation.ts
@@ -1,0 +1,14 @@
+import type { GrantRecipe } from "../types";
+
+export function hasRecipeName(recipe: Pick<GrantRecipe, "description">): boolean {
+  return (recipe.description ?? "").trim().length > 0;
+}
+
+export function requireRecipeName(
+  recipe: Pick<GrantRecipe, "description">,
+  action: string
+): void {
+  if (!hasRecipeName(recipe)) {
+    throw new Error(`Recipe name is required to ${action}.`);
+  }
+}

--- a/src/utils/recipeValidation.ts
+++ b/src/utils/recipeValidation.ts
@@ -4,6 +4,26 @@ export function hasRecipeName(recipe: Pick<GrantRecipe, "description">): boolean
   return (recipe.description ?? "").trim().length > 0;
 }
 
+export function hasUniqueRecipeName(
+  recipe: Pick<GrantRecipe, "id" | "description">,
+  recipes: Pick<GrantRecipe, "id" | "description">[] = []
+): boolean {
+  const recipeName = (recipe.description ?? "").trim().toLowerCase();
+  if (!recipeName) return false;
+
+  return !recipes.some(existing => {
+    const existingName = (existing.description ?? "").trim().toLowerCase();
+    return existing.id !== recipe.id && existingName === recipeName;
+  });
+}
+
+export function isValidRecipe(
+  recipe: Pick<GrantRecipe, "id" | "description"> | null | undefined,
+  recipes: Pick<GrantRecipe, "id" | "description">[] = []
+): recipe is Pick<GrantRecipe, "id" | "description"> {
+  return Boolean(recipe && hasRecipeName(recipe) && hasUniqueRecipeName(recipe, recipes));
+}
+
 export function requireRecipeName(
   recipe: Pick<GrantRecipe, "description">,
   action: string

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,4 @@
 
-import { firebaseClient, FirestoreService } from '@digitalaidseattle/firebase';
 import { vi } from 'vitest';
 
 vi.mock('@digitalaidseattle/firebase', () => {
@@ -14,6 +13,9 @@ vi.mock('@digitalaidseattle/firebase', () => {
     },
     FirebaseAuthService: class {
       getUser = vi.fn();
+    },
+    FirebaseStorageService: class {
+      upload = vi.fn();
     }
   };
 });


### PR DESCRIPTION
## Description

  Requires users to name grant recipes before saving, cloning, or generating
  proposals.

  This change:

  - Displays the “Name your recipe” placeholder and required field indicator.
  - Disables Save, Clone, and Generate while the recipe name is blank.
  - Adds transaction and service level validation to prevent bypassing the
  UI.
  - Creates new recipes locally and persists them only after Save, preventing
  abandoned blank database records.
  - Warns users before leaving an unsaved new recipe.
  - Redirects newly saved recipes to their persisted detail URL.
  - Prevents unnamed recipes from being cloned through the list or dashboard.
  - Adds and updates tests for recipe validation and related transactions.

  Generate remains subject to its existing template and output field
  requirements.

  ## What type of PR is this? (check all applicable)

  - [ ] Refactor
  - [x] Feature
  - [x] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  ## Related Tickets & Documents

https://digital-aid-seattle.atlassian.net/browse/WAVE-121

  ## QA Instructions, Screenshots, Recordings

  1. Open the Grant Recipes list and click Add Recipe.
  2. Verify no blank recipe is immediately added to the database.
  3. Verify the Description field displays the grey placeholder “Name your
  recipe.”
  4. Verify Description has a required field indicator.
  5. Verify Save, Clone, and Generate are disabled while Description is empty
  or whitespace.
  6. Enter a recipe name and verify the name validation no longer disables
  those actions.
  7. Complete any other required template/output fields and verify Generate
  becomes enabled.
  8. Save the recipe and verify it is persisted and the URL changes from `/
  grant-recipes/new` to `/grant-recipes/{id}`.
  9. Create another recipe and navigate back without saving.
  10. Verify a confirmation dialog appears.
  11. Cancel the dialog and verify the editor remains open.
  12. Confirm the dialog and verify navigation continues without creating a
  database record.
  13. Verify refreshing or closing the tab from an unsaved new recipe
  triggers the browser warning.
  14. Verify unnamed recipes cannot be cloned from the recipe list or
  dashboard.